### PR TITLE
Add instruction to prepare for next release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/deep-assistant/hive-mind/issues/11
+Your prepared branch: issue-11-9f0014ca
+Your prepared working directory: /tmp/gh-issue-solver-1757346053359
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/deep-assistant/hive-mind/issues/11
-Your prepared branch: issue-11-9f0014ca
-Your prepared working directory: /tmp/gh-issue-solver-1757346053359
-
-Proceed.

--- a/solve-with-opencode.mjs
+++ b/solve-with-opencode.mjs
@@ -173,7 +173,8 @@ try {
    - When you finalize the pull request, follow style from merged prs for code, title, and description, and double-check the logic of all conditions and statements.  
    - When you code, follow contributing guidelines.  
    - When you commit, write clear message.  
-   - When you open pr, describe solution and include tests.  
+   - When you open pr, describe solution and include tests.
+   - When there is a package with version and GitHub Actions workflows for automatic release, update the version (or other necessary release trigger) in your pull request to prepare for next release.
 
 4. Workflow and collaboration.  
    - When you check branch, verify with git branch --show-current.  

--- a/solve.mjs
+++ b/solve.mjs
@@ -1094,7 +1094,8 @@ Preparing pull request.
    - When you finalize the pull request, follow style from merged prs for code, title, and description, and double-check the logic of all conditions and statements.  
    - When you code, follow contributing guidelines.  
    - When you commit, write clear message.  
-   - When you open pr, describe solution and include tests.${prUrl ? `
+   - When you open pr, describe solution and include tests.
+   - When there is a package with version and GitHub Actions workflows for automatic release, update the version (or other necessary release trigger) in your pull request to prepare for next release.${prUrl ? `
    - When you update existing pr ${prNumber || prUrl}, use gh pr edit to modify title and description.
    - When you finish implementation, use gh pr ready ${prNumber || prUrl}.` : ''}  
 


### PR DESCRIPTION
## Summary

This pull request implements the feature requested in issue #11 by adding a new instruction to the AI issue solver system message.

### Changes Made

- **Updated system prompts** in both  and 
- **Added new instruction**: "When there is a package with version and GitHub Actions workflows for automatic release, update the version (or other necessary release trigger) in your pull request to prepare for next release."
- **Positioned appropriately** in the "Preparing pull request" section of the system message

### Implementation Details

The instruction follows the established "When ..., do ..." pattern and is:
- **General enough** to cover most programming languages and package systems
- **Action-oriented** to guide the AI to look for version files (package.json, pyproject.toml, Cargo.toml, etc.)
- **Contextual** to only trigger when there's evidence of automated release workflows
- **Flexible** to accommodate different release triggers beyond just version numbers

### Test Plan

The instruction is now part of the system message that will be used by the AI issue solver whenever it processes GitHub issues. The AI will automatically check for:
1. Package files with version information
2. GitHub Actions workflows indicating automated releases
3. Update version or other release triggers as appropriate

### Fixes

Closes #11

---
🤖 Generated with [Claude Code](https://claude.ai/code)