### PR TITLE
Add review script to package.json as CLI command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/deep-assistant/hive-mind/issues/90
+Your prepared branch: issue-90-cc02bea4
+Your prepared working directory: /tmp/gh-issue-solver-1757739124569
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/deep-assistant/hive-mind/issues/90
-Your prepared branch: issue-90-cc02bea4
-Your prepared working directory: /tmp/gh-issue-solver-1757739124569
-
-Proceed.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "bin": {
     "hive": "./hive.mjs",
     "solve": "./solve.mjs",
-    "task": "./task.mjs"
+    "task": "./task.mjs",
+    "review": "./review.mjs"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -37,6 +38,7 @@
     "hive.mjs",
     "solve.mjs",
     "task.mjs",
+    "review.mjs",
     "*.md"
   ]
 }


### PR DESCRIPTION
## Summary

This PR adds the existing `review.mjs` script as a CLI command in the package.json to make it easily installable and accessible via npm.

## Changes Made

- Added `"review": "./review.mjs"` to the `bin` section in package.json
- Added `review.mjs` to the `files` array to ensure it's included in the npm package

## Benefits

- Users can now install the package and use the review command directly: `npx @deep-assistant/hive-mind review <pr-url>`
- The review functionality becomes part of the standard CLI toolkit alongside `hive`, `solve`, and `task` commands
- Maintains consistency with the existing CLI command structure

## Testing

The review.mjs script already exists and is functional. This change only makes it accessible as a CLI command through package installation.

Fixes #90

🤖 Generated with [Claude Code](https://claude.ai/code)