### PR TITLE
Fix release publishing workflow permissions issue

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     
     steps:
     - name: Checkout code
@@ -49,26 +52,22 @@ jobs:
         
     - name: Create GitHub Release
       if: steps.version_check.outputs.already_published == 'false'
-      uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: v${{ steps.package.outputs.version }}
-        release_name: Release v${{ steps.package.outputs.version }}
-        body: |
-          ## Changes in v${{ steps.package.outputs.version }}
-          
-          This release includes updates to the @deep-assistant/hive-mind package.
-          
-          ### Installation
-          ```bash
-          npm install -g @deep-assistant/hive-mind
-          ```
-          
-          ### Usage
-          ```bash
-          hive --help
-          solve --help
-          ```
-        draft: false
-        prerelease: false
+      run: |
+        gh release create "v${{ steps.package.outputs.version }}" \
+          --title "Release v${{ steps.package.outputs.version }}" \
+          --notes "## Changes in v${{ steps.package.outputs.version }}
+
+        This release includes updates to the @deep-assistant/hive-mind package.
+
+        ### Installation
+        \`\`\`bash
+        npm install -g @deep-assistant/hive-mind
+        \`\`\`
+
+        ### Usage
+        \`\`\`bash
+        hive --help
+        solve --help
+        \`\`\`"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/deep-assistant/hive-mind/issues/107
+Your prepared branch: issue-107-727bbefe
+Your prepared working directory: /tmp/gh-issue-solver-1757847190366
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/deep-assistant/hive-mind/issues/107
-Your prepared branch: issue-107-727bbefe
-Your prepared working directory: /tmp/gh-issue-solver-1757847190366
-
-Proceed.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deep-assistant/hive-mind",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "AI-powered issue solver and hive mind for collaborative problem solving",
   "main": "hive.mjs",
   "type": "module",


### PR DESCRIPTION
## Summary
- Fixed GitHub Actions workflow that was failing to create releases
- Root cause: Deprecated `actions/create-release@v1` and insufficient permissions
- Solution: Replace with `gh` CLI and add proper workflow permissions

## Problem Analysis
The workflow was failing with "Resource not accessible by integration" error when trying to create GitHub releases. Analysis of the workflow logs showed:
1. NPM publishing was successful 
2. GitHub release creation was failing due to permissions

## Changes Made
- **Added explicit permissions** to workflow: `contents: write` and `packages: write`
- **Replaced deprecated action**: `actions/create-release@v1` → `gh release create` CLI command
- **Modernized approach**: Uses GitHub CLI which is more reliable and maintained
- **Bumped version**: to 0.0.4 to test the workflow fix

## Test Plan
- [x] Updated workflow permissions
- [x] Replaced deprecated action with modern alternative  
- [x] Committed changes and pushed to trigger workflow
- [ ] Verify workflow completes successfully on next package.json change

The fix addresses the core issue identified in #107 where release publishing was failing after NPM publish succeeded.

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #107