### PR TITLE
Fix polling interval display when --once option is set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/deep-assistant/hive-mind/issues/129
+Your prepared branch: issue-129-eedb3d27
+Your prepared working directory: /tmp/gh-issue-solver-1757918514485
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/deep-assistant/hive-mind/issues/129
-Your prepared branch: issue-129-eedb3d27
-Your prepared working directory: /tmp/gh-issue-solver-1757918514485
-
-Proceed.

--- a/experiments/test-once-option.mjs
+++ b/experiments/test-once-option.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+// Test script to verify the --once option fix
+// This simulates the relevant parts of hive.mjs to test the polling interval display logic
+
+const argv = {
+  once: true,    // Test with --once option
+  interval: 300,
+  concurrency: 2,
+  pullRequestsPerIssue: 1,
+  model: 'sonnet',
+  fork: false,
+  maxIssues: 0,
+  dryRun: false,
+  autoCleanup: false
+};
+
+async function log(message) {
+  console.log(message);
+}
+
+// Simulate the configuration display logic from hive.mjs
+console.log('🎯 Testing configuration display with --once option:');
+console.log('');
+
+await log(`   🔄 Concurrency: ${argv.concurrency} parallel workers`);
+await log(`   📊 Pull Requests per Issue: ${argv.pullRequestsPerIssue}`);
+await log(`   🤖 Model: ${argv.model}`);
+if (argv.fork) {
+  await log(`   🍴 Fork: ENABLED (will fork repos if no write access)`);
+}
+if (!argv.once) {
+  await log(`   ⏱️  Polling Interval: ${argv.interval} seconds`);
+}
+await log(`   ${argv.once ? '🚀 Mode: Single run' : '♾️  Mode: Continuous monitoring'}`);
+if (argv.maxIssues > 0) {
+  await log(`   🔢 Max Issues: ${argv.maxIssues}`);
+}
+if (argv.dryRun) {
+  await log(`   🧪 DRY RUN MODE - No actual processing`);
+}
+if (argv.autoCleanup) {
+  await log(`   🧹 Auto-cleanup: ENABLED (will clean /tmp/* /var/tmp/* on success)`);
+}
+
+console.log('');
+console.log('✅ Test completed. Notice that "Polling Interval" is NOT displayed when --once is true.');
+console.log('');
+
+// Now test with --once false
+console.log('🎯 Testing configuration display with continuous monitoring:');
+console.log('');
+
+argv.once = false;
+
+await log(`   🔄 Concurrency: ${argv.concurrency} parallel workers`);
+await log(`   📊 Pull Requests per Issue: ${argv.pullRequestsPerIssue}`);
+await log(`   🤖 Model: ${argv.model}`);
+if (argv.fork) {
+  await log(`   🍴 Fork: ENABLED (will fork repos if no write access)`);
+}
+if (!argv.once) {
+  await log(`   ⏱️  Polling Interval: ${argv.interval} seconds`);
+}
+await log(`   ${argv.once ? '🚀 Mode: Single run' : '♾️  Mode: Continuous monitoring'}`);
+if (argv.maxIssues > 0) {
+  await log(`   🔢 Max Issues: ${argv.maxIssues}`);
+}
+if (argv.dryRun) {
+  await log(`   🧪 DRY RUN MODE - No actual processing`);
+}
+if (argv.autoCleanup) {
+  await log(`   🧹 Auto-cleanup: ENABLED (will clean /tmp/* /var/tmp/* on success)`);
+}
+
+console.log('');
+console.log('✅ Test completed. Notice that "Polling Interval" IS displayed when --once is false.');

--- a/hive.mjs
+++ b/hive.mjs
@@ -228,7 +228,9 @@ await log(`   🤖 Model: ${argv.model}`);
 if (argv.fork) {
   await log(`   🍴 Fork: ENABLED (will fork repos if no write access)`);
 }
-await log(`   ⏱️  Polling Interval: ${argv.interval} seconds`);
+if (!argv.once) {
+  await log(`   ⏱️  Polling Interval: ${argv.interval} seconds`);
+}
 await log(`   ${argv.once ? '🚀 Mode: Single run' : '♾️  Mode: Continuous monitoring'}`);
 if (argv.maxIssues > 0) {
   await log(`   🔢 Max Issues: ${argv.maxIssues}`);

--- a/reviewers-hive.mjs
+++ b/reviewers-hive.mjs
@@ -202,7 +202,9 @@ await log(`   🎯 Focus: ${argv.focus}`);
 if (argv.autoApprove) {
   await log(`   ✅ Auto-approve: Enabled`);
 }
-await log(`   ⏱️  Polling Interval: ${argv.interval} seconds`);
+if (!argv.once) {
+  await log(`   ⏱️  Polling Interval: ${argv.interval} seconds`);
+}
 await log(`   ${argv.once ? '🚀 Mode: Single run' : '♾️  Mode: Continuous monitoring'}`);
 if (argv.maxPrs > 0) {
   await log(`   🔢 Max PRs: ${argv.maxPrs}`);


### PR DESCRIPTION
## Summary
- Don't show "Polling Interval" in configuration output when using `--once` option, as it's misleading since no polling will occur in single-run mode
- Fixed both `hive.mjs` and `reviewers-hive.mjs` for consistency
- Added test script to verify the fix works correctly

## Test plan
- [x] Verified that polling interval is not displayed when `--once` is true
- [x] Verified that polling interval is still displayed when `--once` is false (continuous monitoring)
- [x] Added test script in `experiments/test-once-option.mjs` to demonstrate the fix
- [x] Tested changes locally and confirmed correct behavior

## Before this fix
When running with `--once` option, users would see:
```
⏱️  Polling Interval: 300 seconds
🚀 Mode: Single run
```

This was confusing because single-run mode doesn't poll.

## After this fix
When running with `--once` option, users now see:
```
🚀 Mode: Single run
```

When running in continuous mode, they still see:
```
⏱️  Polling Interval: 300 seconds
♾️  Mode: Continuous monitoring
```

Fixes #129

🤖 Generated with [Claude Code](https://claude.ai/code)