### PR TITLE
Pass --verbose flag from hive.mjs to solve.mjs calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/deep-assistant/hive-mind/issues/148
+Your prepared branch: issue-148-ecc674ac
+Your prepared working directory: /tmp/gh-issue-solver-1757997978256
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/deep-assistant/hive-mind/issues/148
-Your prepared branch: issue-148-ecc674ac
-Your prepared working directory: /tmp/gh-issue-solver-1757997978256
-
-Proceed.

--- a/hive.mjs
+++ b/hive.mjs
@@ -349,7 +349,8 @@ async function worker(workerId) {
       try {
         if (argv.dryRun) {
           const forkFlag = argv.fork ? ' --fork' : '';
-          await log(`   🧪 [DRY RUN] Would execute: ./solve.mjs "${issueUrl}" --model ${argv.model}${forkFlag}`);
+          const verboseFlag = argv.verbose ? ' --verbose' : '';
+          await log(`   🧪 [DRY RUN] Would execute: ./solve.mjs "${issueUrl}" --model ${argv.model}${forkFlag}${verboseFlag}`);
           await new Promise(resolve => setTimeout(resolve, 2000)); // Simulate work
         } else {
           // Execute solve.mjs using spawn to enable real-time streaming while avoiding command-stream quoting issues
@@ -357,18 +358,22 @@ async function worker(workerId) {
           
           const startTime = Date.now();
           const forkFlag = argv.fork ? ' --fork' : '';
-          
+          const verboseFlag = argv.verbose ? ' --verbose' : '';
+
           // Use spawn to get real-time streaming output while avoiding command-stream's automatic quote addition
           const { spawn } = await import('child_process');
-          
+
           // Build arguments array to avoid shell parsing issues
           const args = [issueUrl, '--model', argv.model];
           if (argv.fork) {
             args.push('--fork');
           }
-          
+          if (argv.verbose) {
+            args.push('--verbose');
+          }
+
           // Log the actual command being executed so users can investigate/reproduce
-          const command = `./solve.mjs "${issueUrl}" --model ${argv.model}${forkFlag}`;
+          const command = `./solve.mjs "${issueUrl}" --model ${argv.model}${forkFlag}${verboseFlag}`;
           await log(`   📋 Command: ${command}`);
           
           let exitCode = 0;


### PR DESCRIPTION
## Summary
- Fixed issue where --verbose flag was not being passed from hive.mjs to solve.mjs
- Added verbose flag propagation in three places: spawn arguments, dry-run display, and command logging
- Ensures consistent verbose behavior across the entire hive-mind workflow

## Changes Made
- Modified hive.mjs worker function to include --verbose flag in solve.mjs calls
- Added verboseFlag variable to build proper command display strings
- Updated args array passed to spawn() to include --verbose when enabled

## Test Plan
- [x] Syntax validation of modified files
- [x] Verified solve.mjs accepts --verbose flag
- [x] Code review of argument building logic
- [x] Manual testing of flag propagation paths

Fixes #148

🤖 Generated with [Claude Code](https://claude.ai/code)