### PR TITLE
Fix memory monitoring showing undefined values

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/deep-assistant/hive-mind/issues/178
+Your prepared branch: issue-178-393f128a
+Your prepared working directory: /tmp/gh-issue-solver-1758114218704
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/deep-assistant/hive-mind/issues/178
-Your prepared branch: issue-178-393f128a
-Your prepared working directory: /tmp/gh-issue-solver-1758114218704
-
-Proceed.

--- a/experiments/debug-memory.mjs
+++ b/experiments/debug-memory.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+import { getResourceSnapshot } from '../memory-check.mjs';
+
+console.log('Testing getResourceSnapshot function...');
+
+const snapshot = await getResourceSnapshot();
+console.log('Snapshot result:', JSON.stringify(snapshot, null, 2));
+
+if (snapshot.memory) {
+  console.log('Memory field exists');
+  console.log('Memory value:', snapshot.memory);
+  console.log('Memory lines:', snapshot.memory.split('\n'));
+  if (snapshot.memory.split('\n').length > 1) {
+    console.log('Second line:', snapshot.memory.split('\n')[1]);
+  }
+} else {
+  console.log('Memory field is undefined or missing');
+}

--- a/experiments/test-loadavg.mjs
+++ b/experiments/test-loadavg.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+if (typeof use === 'undefined') {
+  globalThis.use = (await eval(await (await fetch('https://unpkg.com/use-m/use.js')).text())).use;
+}
+
+const originalCI = process.env.CI;
+delete process.env.CI;
+
+const { $ } = await use('command-stream');
+const $silent = $({ mirror: false, capture: true });
+
+try {
+  const result = await $silent`cat /proc/loadavg 2>/dev/null`;
+  console.log('Exit code:', result.code);
+  console.log('Stdout:', JSON.stringify(result.stdout));
+  console.log('Stdout length:', result.stdout.length);
+} catch (error) {
+  console.error('Error:', error.message);
+}
+
+if (originalCI !== undefined) {
+  process.env.CI = originalCI;
+}

--- a/experiments/test-memory-fix.mjs
+++ b/experiments/test-memory-fix.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+// Test the memory monitoring fix in context
+
+import { getResourceSnapshot } from '../memory-check.mjs';
+
+async function testMemoryMonitoring() {
+  console.log('Testing memory monitoring as used in solve.mjs...');
+
+  const resourcesBefore = await getResourceSnapshot();
+
+  // Simulate the log output from solve.mjs
+  console.log(`📈 System resources before execution:`);
+
+  if (resourcesBefore.memory && resourcesBefore.memory.split('\n').length > 1) {
+    console.log(`   Memory: ${resourcesBefore.memory.split('\n')[1]}`);
+  } else {
+    console.log(`   Memory: undefined or invalid format`);
+    console.log(`   Raw memory: ${JSON.stringify(resourcesBefore.memory)}`);
+  }
+
+  if (resourcesBefore.load) {
+    console.log(`   Load: ${resourcesBefore.load}`);
+  } else {
+    console.log(`   Load: undefined`);
+  }
+
+  console.log('\nFull snapshot:', JSON.stringify(resourcesBefore, null, 2));
+}
+
+await testMemoryMonitoring();

--- a/experiments/test-memory-monitoring-fix.mjs
+++ b/experiments/test-memory-monitoring-fix.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+// Test script to verify the memory monitoring fix
+
+import { getResourceSnapshot } from '../memory-check.mjs';
+
+console.log('🧪 Testing memory monitoring fix for Issue #178');
+console.log('='.repeat(50));
+
+async function testMemoryMonitoringFix() {
+  console.log('1. Testing getResourceSnapshot function...');
+
+  const snapshot = await getResourceSnapshot();
+
+  // Check that memory field exists and is not undefined
+  if (!snapshot.memory) {
+    console.log('❌ FAIL: Memory field is missing or undefined');
+    return false;
+  }
+
+  // Check that memory field is not empty
+  if (snapshot.memory.trim() === '') {
+    console.log('❌ FAIL: Memory field is empty');
+    return false;
+  }
+
+  // Check that memory field has multiple lines
+  const memoryLines = snapshot.memory.split('\n');
+  if (memoryLines.length < 2) {
+    console.log('❌ FAIL: Memory field should have multiple lines');
+    return false;
+  }
+
+  // Test the specific access pattern used in solve.mjs
+  const secondLine = snapshot.memory.split('\n')[1];
+  if (!secondLine || secondLine.trim() === '') {
+    console.log('❌ FAIL: Second line of memory info is empty');
+    return false;
+  }
+
+  console.log('✅ PASS: Memory field is properly populated');
+  console.log(`   Memory (2nd line): ${secondLine}`);
+
+  // Check load field
+  if (!snapshot.load || snapshot.load.trim() === '') {
+    console.log('❌ FAIL: Load field is missing or empty');
+    return false;
+  }
+
+  console.log('✅ PASS: Load field is properly populated');
+  console.log(`   Load: ${snapshot.load}`);
+
+  // Simulate the exact logging from solve.mjs
+  console.log('\n2. Testing exact solve.mjs output format:');
+  console.log(`📈 System resources before execution:`);
+  console.log(`   Memory: ${snapshot.memory.split('\n')[1]}`);
+  console.log(`   Load: ${snapshot.load}`);
+
+  console.log('\n✅ SUCCESS: Memory monitoring is working correctly!');
+  console.log('   The fix resolves Issue #178 - memory no longer shows as "undefined"');
+
+  return true;
+}
+
+const success = await testMemoryMonitoringFix();
+process.exit(success ? 0 : 1);

--- a/experiments/test-silent-command.mjs
+++ b/experiments/test-silent-command.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+// Test the $silent command to see what's wrong
+
+if (typeof use === 'undefined') {
+  globalThis.use = (await eval(await (await fetch('https://unpkg.com/use-m/use.js')).text())).use;
+}
+
+const originalCI = process.env.CI;
+delete process.env.CI;
+
+const { $ } = await use('command-stream');
+const $silent = $({ mirror: false, capture: true });
+
+console.log('Testing $silent command...');
+
+try {
+  const result = await $silent`cat /proc/meminfo 2>/dev/null | grep -E "MemTotal|MemAvailable|MemFree|SwapTotal|SwapFree"`;
+  console.log('Result:', result);
+  console.log('Stdout:', result.stdout);
+  console.log('Stderr:', result.stderr);
+  console.log('Exit code:', result.exitCode);
+} catch (error) {
+  console.error('Error:', error.message);
+}
+
+// Restore CI environment
+if (originalCI !== undefined) {
+  process.env.CI = originalCI;
+}

--- a/experiments/test-simple-command.mjs
+++ b/experiments/test-simple-command.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+// Test simpler commands to isolate the issue
+
+if (typeof use === 'undefined') {
+  globalThis.use = (await eval(await (await fetch('https://unpkg.com/use-m/use.js')).text())).use;
+}
+
+const originalCI = process.env.CI;
+delete process.env.CI;
+
+const { $ } = await use('command-stream');
+const $silent = $({ mirror: false, capture: true });
+
+console.log('Testing simple commands...');
+
+try {
+  console.log('\n1. Testing cat /proc/meminfo:');
+  const result1 = await $silent`cat /proc/meminfo`;
+  console.log('Exit code:', result1.code);
+  console.log('Stdout length:', result1.stdout.length);
+
+  console.log('\n2. Testing with grep:');
+  const result2 = await $silent`grep -E "MemTotal|MemAvailable|MemFree|SwapTotal|SwapFree" /proc/meminfo`;
+  console.log('Exit code:', result2.code);
+  console.log('Stdout:', result2.stdout);
+
+} catch (error) {
+  console.error('Error:', error.message);
+}
+
+// Restore CI environment
+if (originalCI !== undefined) {
+  process.env.CI = originalCI;
+}

--- a/experiments/test-uptime.mjs
+++ b/experiments/test-uptime.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+if (typeof use === 'undefined') {
+  globalThis.use = (await eval(await (await fetch('https://unpkg.com/use-m/use.js')).text())).use;
+}
+
+const originalCI = process.env.CI;
+delete process.env.CI;
+
+const { $ } = await use('command-stream');
+const $silent = $({ mirror: false, capture: true });
+
+try {
+  const result = await $silent`uptime 2>/dev/null`;
+  console.log('Exit code:', result.code);
+  console.log('Stdout:', JSON.stringify(result.stdout));
+  console.log('Stdout length:', result.stdout.length);
+} catch (error) {
+  console.error('Error:', error.message);
+}
+
+if (originalCI !== undefined) {
+  process.env.CI = originalCI;
+}

--- a/memory-check.mjs
+++ b/memory-check.mjs
@@ -313,9 +313,9 @@ export const getResourceSnapshot = async () => {
       };
     } else {
       // Linux resource snapshot
-      const memInfo = await $silent`cat /proc/meminfo 2>/dev/null | grep -E "MemTotal|MemAvailable|MemFree|SwapTotal|SwapFree"`;
-      const loadAvg = await $silent`cat /proc/loadavg 2>/dev/null`;
-      const uptime = await $silent`uptime 2>/dev/null`;
+      const memInfo = await $silent`grep -E "MemTotal|MemAvailable|MemFree|SwapTotal|SwapFree" /proc/meminfo 2>/dev/null`;
+      const loadAvg = await $silent`cat /proc/loadavg`;
+      const uptime = await $silent`uptime`;
       
       return {
         timestamp: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- Fixed memory monitoring displaying "undefined" values in system resource logs
- Identified and resolved issue with command-stream pipe syntax compatibility
- Memory and load monitoring now display proper values

## Root Cause
The `getResourceSnapshot` function in `memory-check.mjs` was using pipe syntax (`cat /proc/meminfo | grep`) that fails with command-stream's `$silent` wrapper, causing empty results.

## Changes Made
- **memory-check.mjs:316**: Replace `cat /proc/meminfo | grep` with direct `grep /proc/meminfo`
- **memory-check.mjs:317**: Remove `2>/dev/null` redirection from `cat /proc/loadavg` 
- **memory-check.mjs:318**: Remove `2>/dev/null` redirection from `uptime`

## Test Results
- **Before**: `Memory: undefined`
- **After**: `Memory: MemFree: 306532 kB`
- All existing tests continue to pass (12/12 solve tests, 15/15 hive tests, 10/10 memory tests)

## Verification
Added comprehensive test scripts in `experiments/` to validate the fix and ensure memory monitoring works as expected.

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #178