### PR TITLE
Remove deprecated force-claude runtime options from README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/deep-assistant/hive-mind/issues/181
+Your prepared branch: issue-181-a1e1bca2
+Your prepared working directory: /tmp/gh-issue-solver-1758161376017
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/deep-assistant/hive-mind/issues/181
-Your prepared branch: issue-181-a1e1bca2
-Your prepared working directory: /tmp/gh-issue-solver-1758161376017
-
-Proceed.

--- a/README.md
+++ b/README.md
@@ -102,8 +102,6 @@ curl -fsSL -o- https://github.com/deep-assistant/hive-mind/raw/refs/heads/main/u
   --min-disk-space      Minimum disk space in MB             [default: 500]
   --auto-cleanup        Clean /tmp/* /var/tmp/* on success   [default: false]
   --fork, -f            Fork repos if no write access       [default: false]
-  --force-claude-bun-run     Switch Claude to bun runtime    [default: false]
-  --force-claude-nodejs-run  Restore Claude to Node.js       [default: false]
 ```
 
 ## 🏗️ Architecture


### PR DESCRIPTION
## Summary

- Removed `--force-claude-bun-run` and `--force-claude-nodejs-run` options from the README.md documentation for `hive.mjs`
- Verified that these options are not present in the actual code implementation (`hive.mjs` and `solve.mjs`)
- These options were documented but not implemented, causing confusion

## Changes Made

- Removed lines 105-106 from README.md containing the deprecated options:
  ```
  --force-claude-bun-run     Switch Claude to bun runtime    [default: false]
  --force-claude-nodejs-run  Restore Claude to Node.js       [default: false]
  ```

## Test Plan

- [x] Verified options are not present in `hive.mjs` code
- [x] Verified options are not present in `solve.mjs` code  
- [x] Confirmed options are removed from README.md
- [x] Documentation now accurately reflects actual implementation

Fixes #181

🤖 Generated with [Claude Code](https://claude.ai/code)