### PR TITLE
fix: Log raw executed command for better debugging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/deep-assistant/hive-mind/issues/209
+Your prepared branch: issue-209-a1153107
+Your prepared working directory: /tmp/gh-issue-solver-1758348148365
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/deep-assistant/hive-mind/issues/209
-Your prepared branch: issue-209-a1153107
-Your prepared working directory: /tmp/gh-issue-solver-1758348148365
-
-Proceed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@deep-assistant/hive-mind",
-  "version": "0.7.1",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@deep-assistant/hive-mind",
-      "version": "0.7.1",
+      "version": "0.7.4",
       "license": "Unlicense",
       "bin": {
         "hive": "src/hive.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deep-assistant/hive-mind",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "AI-powered issue solver and hive mind for collaborative problem solving",
   "main": "src/hive.mjs",
   "type": "module",

--- a/src/solve.claude-execution.lib.mjs
+++ b/src/solve.claude-execution.lib.mjs
@@ -65,7 +65,12 @@ export const executeClaudeCommand = async (params) => {
 
   // Print the command being executed (with cd for reproducibility)
   const fullCommand = `(cd "${tempDir}" && ${claudePath} ${claudeArgs} | jq -c .)`;
-  await log(`\n${formatAligned('📋', 'Command details:', '')}`);
+
+  // Log the raw command for debugging and reproducibility
+  await log(`\n${formatAligned('📝', 'Raw command:', '')}`);
+  await log(`${fullCommand}\n`);
+
+  await log(`${formatAligned('📋', 'Command details:', '')}`);
   await log(formatAligned('📂', 'Working directory:', tempDir, 2));
   await log(formatAligned('🌿', 'Branch:', branchName, 2));
   await log(formatAligned('🤖', 'Model:', `Claude ${argv.model.toUpperCase()}`, 2));


### PR DESCRIPTION
## 📋 Summary

This PR fixes issue #209 by ensuring that the raw executed command is always logged, making it easier for users to debug issues by simply uploading their log to a gist and sharing the link.

## 🔗 Issue Reference
Fixes #209

## 🚀 Changes Made

- Added logging of the full raw command before Claude execution in `solve.claude-execution.lib.mjs`
- The raw command includes the working directory and all arguments in a copy-pasteable format
- Users can now see exactly what command was executed, making debugging much easier

## 📝 Example Output

When running the solve command, users will now see:
```
📝 Raw command:
(cd "/tmp/gh-issue-solver-1234" && claude --output-format stream-json --verbose --dangerously-skip-permissions --model opus -p "..." --append-system-prompt "..." | jq -c .)

📋 Command details:
  📂 Working directory:     /tmp/gh-issue-solver-1234
  🌿 Branch:                issue-123-branch
  🤖 Model:                 Claude OPUS
```

## ✅ Benefits

1. **Better Debugging**: Users can now copy the exact command from logs to reproduce issues
2. **Easier Support**: When users share logs (via gist), support can see the exact command that was executed
3. **Full Transparency**: Complete visibility into what the tool is executing

## 🧪 Testing

The change has been verified to:
- Log the raw command with all arguments
- Preserve the existing formatted command details
- Work with both regular and resume modes

---
*This PR was completed with assistance from the AI issue solver*