### PR TITLE
fix: Fix getResourceSnapshot import error in watch mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/deep-assistant/hive-mind/issues/266
+Your prepared branch: issue-266-91b86b14
+Your prepared working directory: /tmp/gh-issue-solver-1758454834830
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/deep-assistant/hive-mind/issues/266
-Your prepared branch: issue-266-91b86b14
-Your prepared working directory: /tmp/gh-issue-solver-1758454834830
-
-Proceed.

--- a/experiments/test-import-fix.mjs
+++ b/experiments/test-import-fix.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+// Test that the import fix works correctly
+console.log('Testing import fix for getResourceSnapshot...\n');
+
+try {
+  // Test importing from memory-check.mjs (the correct module)
+  const memoryCheck = await import('../src/memory-check.mjs');
+  const { getResourceSnapshot } = memoryCheck;
+
+  console.log('✅ Import from memory-check.mjs successful');
+  console.log('✅ getResourceSnapshot is a function:', typeof getResourceSnapshot === 'function');
+
+  // Try calling it to ensure it actually works
+  const snapshot = await getResourceSnapshot();
+  console.log('✅ getResourceSnapshot() executed successfully');
+  console.log('   Memory usage:', snapshot.memory);
+  console.log('   CPU usage:', snapshot.cpu);
+
+} catch (error) {
+  console.error('❌ Test failed:', error.message);
+  process.exit(1);
+}
+
+console.log('\n✅ All tests passed! The import fix is working correctly.');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deep-assistant/hive-mind",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "AI-powered issue solver and hive mind for collaborative problem solving",
   "main": "src/hive.mjs",
   "type": "module",

--- a/src/solve.watch.lib.mjs
+++ b/src/solve.watch.lib.mjs
@@ -204,8 +204,8 @@ export const watchForFeedback = async (params) => {
         // Import necessary modules for claude execution
         const claudeExecLib = await import('./solve.claude-execution.lib.mjs');
         const { executeClaude } = claudeExecLib;
-        const repoLib = await import('./solve.repository.lib.mjs');
-        const { getResourceSnapshot } = repoLib;
+        const memoryCheck = await import('./memory-check.mjs');
+        const { getResourceSnapshot } = memoryCheck;
 
         // Get claude path
         const claudePath = argv.claudePath || 'claude';


### PR DESCRIPTION
## Summary
- Fixed the "getResourceSnapshot is not a function" error in watch mode
- The function was being imported from the wrong module
- Added test to verify the import works correctly

## Problem
The watch mode was failing with the error: "getResourceSnapshot is not a function". This occurred when watch mode tried to restart Claude after detecting feedback.

## Root Cause
In `src/solve.watch.lib.mjs` (line 208), the code was trying to import `getResourceSnapshot` from `./solve.repository.lib.mjs`, but this function is not exported from that module. The function is actually exported from `./memory-check.mjs`.

## Solution
Changed the import statement to use the correct module:
```javascript
// Before (incorrect):
const repoLib = await import('./solve.repository.lib.mjs');
const { getResourceSnapshot } = repoLib;

// After (correct):
const memoryCheck = await import('./memory-check.mjs');
const { getResourceSnapshot } = memoryCheck;
```

This matches the pattern used in `solve.mjs` (line 190) where the function is correctly imported from memory-check.

## Test plan
- [x] Added `experiments/test-import-fix.mjs` to verify the import works
- [x] Tested that `getResourceSnapshot` is properly imported and callable
- [x] Verified the function executes successfully and returns expected data

Fixes #266

🤖 Generated with [Claude Code](https://claude.ai/code)