### PR TITLE
feat: Add --think-ultra-hard option to enhance AI reasoning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/deep-assistant/hive-mind/issues/282
+Your prepared branch: issue-282-0dd3423e
+Your prepared working directory: /tmp/gh-issue-solver-1758693628755
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/deep-assistant/hive-mind/issues/282
-Your prepared branch: issue-282-0dd3423e
-Your prepared working directory: /tmp/gh-issue-solver-1758693628755
-
-Proceed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@deep-assistant/hive-mind",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@deep-assistant/hive-mind",
-      "version": "0.10.2",
+      "version": "0.11.0",
       "license": "Unlicense",
       "bin": {
         "hive": "src/hive.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deep-assistant/hive-mind",
-  "version": "0.10.6",
+  "version": "0.11.0",
   "description": "AI-powered issue solver and hive mind for collaborative problem solving",
   "main": "src/hive.mjs",
   "type": "module",

--- a/src/hive.mjs
+++ b/src/hive.mjs
@@ -265,6 +265,11 @@ const createYargsConfig = (yargsInstance) => {
       description: 'Automatically continue working on issues with existing PRs (older than 24 hours)',
       default: false
     })
+    .option('think-ultra-hard', {
+      type: 'boolean',
+      description: 'Add "You always think ultra hard on every step" to system prompt',
+      default: false
+    })
     .help('h')
     .alias('h', 'help');
 };
@@ -609,6 +614,7 @@ async function worker(workerId) {
         const dryRunFlag = argv.dryRun ? ' --dry-run' : '';
         const skipClaudeCheckFlag = argv.skipClaudeCheck ? ' --skip-claude-check' : '';
         const autoContinueFlag = argv.autoContinue ? ' --auto-continue' : '';
+        const thinkUltraHardFlag = argv.thinkUltraHard ? ' --think-ultra-hard' : '';
 
         // Use spawn to get real-time streaming output while avoiding command-stream's automatic quote addition
         const { spawn } = await import('child_process');
@@ -636,9 +642,12 @@ async function worker(workerId) {
         if (argv.autoContinue) {
           args.push('--auto-continue');
         }
+        if (argv.thinkUltraHard) {
+          args.push('--think-ultra-hard');
+        }
 
         // Log the actual command being executed so users can investigate/reproduce
-        const command = `${solveCommand} "${issueUrl}" --model ${argv.model}${forkFlag}${verboseFlag}${attachLogsFlag}${logDirFlag}${dryRunFlag}${skipClaudeCheckFlag}${autoContinueFlag}`;
+        const command = `${solveCommand} "${issueUrl}" --model ${argv.model}${forkFlag}${verboseFlag}${attachLogsFlag}${logDirFlag}${dryRunFlag}${skipClaudeCheckFlag}${autoContinueFlag}${thinkUltraHardFlag}`;
         await log(`   📋 Command: ${command}`);
 
         let exitCode = 0;

--- a/src/solve.claude-execution.lib.mjs
+++ b/src/solve.claude-execution.lib.mjs
@@ -81,10 +81,13 @@ export const buildUserPrompt = (params) => {
  * @returns {string} The formatted system prompt
  */
 export const buildSystemPrompt = (params) => {
-  const { owner, repo, issueNumber, prNumber, branchName } = params;
+  const { owner, repo, issueNumber, prNumber, branchName, argv } = params;
+
+  // Check if think-ultra-hard option is enabled
+  const thinkUltraHardLine = argv && argv.thinkUltraHard ? '\nYou always think ultra hard on every step.\n' : '';
 
   // Use backticks for jq commands to avoid quote escaping issues
-  return `You are AI issue solver.
+  return `You are AI issue solver.${thinkUltraHardLine}
 
 General guidelines.
    - When you execute commands, always save their logs to files for easy reading if the output gets large.

--- a/src/solve.config.lib.mjs
+++ b/src/solve.config.lib.mjs
@@ -122,6 +122,11 @@ export const createYargsConfig = (yargsInstance) => {
       description: 'Directory to save log files (defaults to current working directory)',
       alias: 'l'
     })
+    .option('think-ultra-hard', {
+      type: 'boolean',
+      description: 'Add "You always think ultra hard on every step" to system prompt',
+      default: false
+    })
     .help('h')
     .alias('h', 'help');
 };


### PR DESCRIPTION
## Summary
This PR implements the `--think-ultra-hard` option as requested in issue #282. When enabled, this option adds the instruction "You always think ultra hard on every step" to the AI's system prompt.

## Implementation Details
- Added `--think-ultra-hard` CLI option to `solve.config.lib.mjs`
- Updated `buildSystemPrompt` function in `solve.claude-execution.lib.mjs` to conditionally include the extra instruction
- Added the same option to `hive.mjs` for consistency
- Ensured proper option propagation from `hive` command to `solve` command
- Option is disabled by default to maintain backward compatibility

## Testing
- Verified that `--help` displays the new option correctly for both `solve.mjs` and `hive.mjs`
- Tested system prompt generation with and without the option
- Confirmed syntax validity of all modified files
- Tested option propagation from hive to solve commands

## Usage
```bash
# Using with solve.mjs directly
./solve.mjs <issue-url> --think-ultra-hard

# Using with hive.mjs
./hive.mjs <github-url> --think-ultra-hard
```

Fixes #282