### PR TITLE
fix: Add 'Think ultra hard.' to user prompt when --think-ultra-hard is enabled

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/deep-assistant/hive-mind/issues/290
-Your prepared branch: issue-290-d22ff7e9
-Your prepared working directory: /tmp/gh-issue-solver-1758726221332
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/deep-assistant/hive-mind/issues/290
+Your prepared branch: issue-290-d22ff7e9
+Your prepared working directory: /tmp/gh-issue-solver-1758726221332
+
+Proceed.

--- a/experiments/test-think-ultra-hard.mjs
+++ b/experiments/test-think-ultra-hard.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+/**
+ * Test script to verify the --think-ultra-hard option behavior
+ */
+
+import { buildUserPrompt, buildSystemPrompt } from '../src/solve.claude-execution.lib.mjs';
+
+// Test cases
+const testCases = [
+  {
+    name: 'Without --think-ultra-hard option',
+    params: {
+      issueUrl: 'https://github.com/test/repo/issues/1',
+      issueNumber: '1',
+      prNumber: '2',
+      prUrl: 'https://github.com/test/repo/pull/2',
+      branchName: 'test-branch',
+      tempDir: '/tmp/test',
+      isContinueMode: false,
+      owner: 'test',
+      repo: 'repo',
+      argv: { thinkUltraHard: false }
+    }
+  },
+  {
+    name: 'With --think-ultra-hard option (normal mode)',
+    params: {
+      issueUrl: 'https://github.com/test/repo/issues/1',
+      issueNumber: '1',
+      prNumber: '2',
+      prUrl: 'https://github.com/test/repo/pull/2',
+      branchName: 'test-branch',
+      tempDir: '/tmp/test',
+      isContinueMode: false,
+      owner: 'test',
+      repo: 'repo',
+      argv: { thinkUltraHard: true }
+    }
+  },
+  {
+    name: 'With --think-ultra-hard option (continue mode)',
+    params: {
+      issueUrl: 'https://github.com/test/repo/issues/1',
+      issueNumber: '1',
+      prNumber: '2',
+      prUrl: 'https://github.com/test/repo/pull/2',
+      branchName: 'test-branch',
+      tempDir: '/tmp/test',
+      isContinueMode: true,
+      owner: 'test',
+      repo: 'repo',
+      argv: { thinkUltraHard: true }
+    }
+  }
+];
+
+console.log('Testing --think-ultra-hard option implementation\n');
+console.log('=' .repeat(80));
+
+testCases.forEach(testCase => {
+  console.log(`\nTest: ${testCase.name}`);
+  console.log('-'.repeat(40));
+
+  // Build user prompt
+  const userPrompt = buildUserPrompt(testCase.params);
+
+  // Build system prompt
+  const systemPrompt = buildSystemPrompt(testCase.params);
+
+  console.log('\nUser Prompt (last 5 lines):');
+  const userPromptLines = userPrompt.split('\n');
+  const lastLines = userPromptLines.slice(-5);
+  lastLines.forEach(line => console.log(`  > ${line}`));
+
+  console.log('\nSystem Prompt (first 2 lines):');
+  const systemPromptLines = systemPrompt.split('\n');
+  const firstLines = systemPromptLines.slice(0, 2);
+  firstLines.forEach(line => console.log(`  > ${line}`));
+
+  // Verify the behavior
+  if (testCase.params.argv.thinkUltraHard) {
+    // Check system prompt
+    if (systemPrompt.includes('You always think ultra hard on every step.')) {
+      console.log('✅ System prompt contains "You always think ultra hard on every step."');
+    } else {
+      console.log('❌ System prompt MISSING "You always think ultra hard on every step."');
+    }
+
+    // Check user prompt
+    if (userPrompt.includes('Think ultra hard.')) {
+      console.log('✅ User prompt contains "Think ultra hard." before final instruction');
+    } else {
+      console.log('❌ User prompt MISSING "Think ultra hard." before final instruction');
+    }
+  } else {
+    // Check that the lines are NOT added when option is disabled
+    if (!systemPrompt.includes('You always think ultra hard on every step.')) {
+      console.log('✅ System prompt correctly omits ultra-hard line when option disabled');
+    }
+    if (!userPrompt.includes('Think ultra hard.')) {
+      console.log('✅ User prompt correctly omits "Think ultra hard." when option disabled');
+    }
+  }
+});
+
+console.log('\n' + '='.repeat(80));
+console.log('Test completed successfully!');

--- a/issue_290.json
+++ b/issue_290.json
@@ -1,0 +1,1 @@
+{"body":"","comments":[],"title":"When --think-ultra-hard option is enabled, we should also add `Think ultra hard.` line before `Proceed.` and `Continue.` in the main prompt"}

--- a/lint_output.txt
+++ b/lint_output.txt
@@ -1,5 +1,5 @@
 
-> @deep-assistant/hive-mind@0.12.0 lint
+> @deep-assistant/hive-mind@0.12.1 lint
 > eslint src/hive.mjs src/solve.mjs src/solve.*.lib.mjs src/lib.mjs src/claude.lib.mjs src/github.lib.mjs src/memory-check.mjs
 
 sh: 1: eslint: not found

--- a/lint_results.txt
+++ b/lint_results.txt
@@ -1,0 +1,120 @@
+
+> @deep-assistant/hive-mind@0.12.1 lint
+> eslint src/hive.mjs src/solve.mjs src/solve.*.lib.mjs src/lib.mjs src/claude.lib.mjs src/github.lib.mjs src/memory-check.mjs
+
+
+/tmp/gh-issue-solver-1758726221332/src/claude.lib.mjs
+    8:7   warning  'use' is assigned a value but never used  no-unused-vars
+   85:18  warning  'e' is defined but never used             no-unused-vars
+  194:16  warning  'bunError' is defined but never used      no-unused-vars
+  213:16  warning  'accessError' is defined but never used   no-unused-vars
+  264:16  warning  'nodeError' is defined but never used     no-unused-vars
+  283:16  warning  'accessError' is defined but never used   no-unused-vars
+  306:16  warning  'backupError' is defined but never used   no-unused-vars
+
+/tmp/gh-issue-solver-1758726221332/src/github.lib.mjs
+    8:7   warning  'use' is assigned a value but never used     no-unused-vars
+   55:12  warning  'error' is defined but never used            no-unused-vars
+   90:12  warning  'error' is defined but never used            no-unused-vars
+  149:12  warning  'error' is defined but never used            no-unused-vars
+  343:18  warning  'visibilityError' is defined but never used  no-unused-vars
+  625:14  warning  'error' is defined but never used            no-unused-vars
+  909:12  warning  'e' is defined but never used                no-unused-vars
+
+/tmp/gh-issue-solver-1758726221332/src/hive.mjs
+   21:62   warning  'formatAligned' is assigned a value but never used                        no-unused-vars
+   21:77   warning  'displayFormattedError' is assigned a value but never used                no-unused-vars
+   29:150  warning  'normalizeGitHubUrl' is assigned a value but never used                   no-unused-vars
+   41:54   warning  'reportError' is assigned a value but never used                          no-unused-vars
+   41:67   warning  'flushSentry' is assigned a value but never used                          no-unused-vars
+   41:80   warning  'closeSentry' is assigned a value but never used                          no-unused-vars
+  373:10   warning  'error' is defined but never used                                         no-unused-vars
+  377:12   warning  'mkdirError' is defined but never used                                    no-unused-vars
+  497:12   warning  'e' is defined but never used                                             no-unused-vars
+  691:37   warning  'reject' is defined but never used. Allowed unused args must match /^_/u  no-unused-vars
+  935:19   warning  'repoKey' is assigned a value but never used                              no-unused-vars
+
+/tmp/gh-issue-solver-1758726221332/src/lib.mjs
+    9:7   warning  'use' is assigned a value but never used  no-unused-vars
+  113:12  warning  'error' is defined but never used         no-unused-vars
+
+/tmp/gh-issue-solver-1758726221332/src/memory-check.mjs
+  344:11  warning  'log' is assigned a value but never used  no-unused-vars
+
+/tmp/gh-issue-solver-1758726221332/src/solve.branch-errors.lib.mjs
+  45:20  warning  'e' is defined but never used  no-unused-vars
+  50:14  warning  'e' is defined but never used  no-unused-vars
+  75:24  warning  'e' is defined but never used  no-unused-vars
+  82:14  warning  'e' is defined but never used  no-unused-vars
+
+/tmp/gh-issue-solver-1758726221332/src/solve.claude-execution.lib.mjs
+  6:8  warning  'fs' is defined but never used    no-unused-vars
+  7:8  warning  'path' is defined but never used  no-unused-vars
+  8:8  warning  'os' is defined but never used    no-unused-vars
+
+/tmp/gh-issue-solver-1758726221332/src/solve.execution.lib.mjs
+   20:7    warning  'crypto' is assigned a value but never used                                    no-unused-vars
+   60:14   warning  'err' is defined but never used                                                no-unused-vars
+  222:14   warning  'cleanupError' is defined but never used                                       no-unused-vars
+  235:67   warning  'claudePath' is defined but never used. Allowed unused args must match /^_/u   no-unused-vars
+  235:79   warning  'argv' is defined but never used. Allowed unused args must match /^_/u         no-unused-vars
+  235:85   warning  'issueUrl' is defined but never used. Allowed unused args must match /^_/u     no-unused-vars
+  235:95   warning  'sessionId' is defined but never used. Allowed unused args must match /^_/u    no-unused-vars
+  235:106  warning  'owner' is defined but never used. Allowed unused args must match /^_/u        no-unused-vars
+  235:113  warning  'repo' is defined but never used. Allowed unused args must match /^_/u         no-unused-vars
+  235:119  warning  'issueNumber' is defined but never used. Allowed unused args must match /^_/u  no-unused-vars
+
+/tmp/gh-issue-solver-1758726221332/src/solve.mjs
+    55:43   warning  'createYargsConfig' is assigned a value but never used                no-unused-vars
+    59:27   warning  'withSentry' is assigned a value but never used                       no-unused-vars
+    59:54   warning  'reportError' is assigned a value but never used                      no-unused-vars
+    59:67   warning  'flushSentry' is assigned a value but never used                      no-unused-vars
+    59:80   warning  'closeSentry' is assigned a value but never used                      no-unused-vars
+    61:7    warning  'os' is assigned a value but never used                               no-unused-vars
+    67:14   warning  'setLogFile' is assigned a value but never used                       no-unused-vars
+    69:29   warning  'checkFileInBranch' is assigned a value but never used                no-unused-vars
+    69:48   warning  'checkGitHubPermissions' is assigned a value but never used           no-unused-vars
+    71:9    warning  'validateClaudeConnection' is assigned a value but never used         no-unused-vars
+    73:167  warning  'parseResetTime' is assigned a value but never used                   no-unused-vars
+    73:183  warning  'calculateWaitTime' is assigned a value but never used                no-unused-vars
+    75:9    warning  'autoContinueWhenLimitResets' is assigned a value but never used      no-unused-vars
+    75:38   warning  'checkExistingPRsForAutoContinue' is assigned a value but never used  no-unused-vars
+    75:71   warning  'processPRMode' is assigned a value but never used                    no-unused-vars
+    79:63   warning  'handleExecutionError' is assigned a value but never used             no-unused-vars
+    81:24   warning  'executeClaudeCommand' is assigned a value but never used             no-unused-vars
+    81:46   warning  'buildSystemPrompt' is assigned a value but never used                no-unused-vars
+    81:65   warning  'buildUserPrompt' is assigned a value but never used                  no-unused-vars
+   266:5    warning  'isForkPR' is assigned a value but never used                         no-unused-vars
+   295:18   warning  'isResuming' is assigned a value but never used                       no-unused-vars
+   628:22   warning  'e' is defined but never used                                         no-unused-vars
+   779:22   warning  'e' is defined but never used                                         no-unused-vars
+  1005:26   warning  'parseErr' is defined but never used                                  no-unused-vars
+  1101:9    warning  'newPrComments' is assigned a value but never used                    no-unused-vars
+  1101:24   warning  'newIssueComments' is assigned a value but never used                 no-unused-vars
+  1101:42   warning  'commentInfo' is assigned a value but never used                      no-unused-vars
+  1239:31   warning  'messageCount' is assigned a value but never used                     no-unused-vars
+  1239:45   warning  'toolUseCount' is assigned a value but never used                     no-unused-vars
+
+/tmp/gh-issue-solver-1758726221332/src/solve.repository.lib.mjs
+   50:14  warning  'err' is defined but never used           no-unused-vars
+  379:14  warning  'cleanupError' is defined but never used  no-unused-vars
+
+/tmp/gh-issue-solver-1758726221332/src/solve.results.lib.mjs
+  47:3   warning  'handleFailure' is assigned a value but never used  no-unused-vars
+  71:12  warning  'e' is defined but never used                       no-unused-vars
+
+/tmp/gh-issue-solver-1758726221332/src/solve.validation.lib.mjs
+   25:3   warning  'getLogFile' is assigned a value but never used       no-unused-vars
+   33:3   warning  'isGitHubUrlType' is assigned a value but never used  no-unused-vars
+  143:12  warning  'error' is defined but never used                     no-unused-vars
+  147:14  warning  'mkdirError' is defined but never used                no-unused-vars
+
+/tmp/gh-issue-solver-1758726221332/src/solve.watch.lib.mjs
+   35:12  warning  'error' is defined but never used                   no-unused-vars
+   52:12  warning  'error' is defined but never used                   no-unused-vars
+  166:20  warning  'e' is defined but never used                       no-unused-vars
+  192:20  warning  'e' is defined but never used                       no-unused-vars
+  243:9   warning  'lastCheckTime' is assigned a value but never used  no-unused-vars
+
+✖ 87 problems (0 errors, 87 warnings)
+

--- a/npm_install.txt
+++ b/npm_install.txt
@@ -1,0 +1,7 @@
+
+added 160 packages, and audited 161 packages in 9s
+
+27 packages are looking for funding
+  run `npm fund` for details
+
+found 0 vulnerabilities

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@deep-assistant/hive-mind",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@deep-assistant/hive-mind",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "Unlicense",
       "dependencies": {
         "@sentry/node": "^10.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deep-assistant/hive-mind",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "AI-powered issue solver and hive mind for collaborative problem solving",
   "main": "src/hive.mjs",
   "type": "module",

--- a/src/solve.claude-execution.lib.mjs
+++ b/src/solve.claude-execution.lib.mjs
@@ -68,6 +68,11 @@ export const buildUserPrompt = (params) => {
     promptLines.push('');
   }
 
+  // Add "Think ultra hard." if the option is enabled
+  if (argv && argv.thinkUltraHard) {
+    promptLines.push('Think ultra hard.');
+  }
+
   // Final instruction
   promptLines.push(isContinueMode ? 'Continue.' : 'Proceed.');
 

--- a/test_output.txt
+++ b/test_output.txt
@@ -1,0 +1,5 @@
+
+> @deep-assistant/hive-mind@0.12.1 test
+> echo "Error: no test specified" && exit 1
+
+Error: no test specified


### PR DESCRIPTION
## Summary

This PR fixes the issue where the `--think-ultra-hard` option only added the instruction to the system prompt but not to the user prompt.

### Changes
- Added `Think ultra hard.` line before `Proceed.` and `Continue.` in the user prompt when `--think-ultra-hard` option is enabled
- The system prompt already contained `You always think ultra hard on every step.` and remains unchanged
- Added test script to verify the correct behavior

## Test plan

Created and ran test script `experiments/test-think-ultra-hard.mjs` that verifies:
- ✅ Without `--think-ultra-hard`: No ultra-hard lines are added to either prompt
- ✅ With `--think-ultra-hard` (normal mode): Both prompts contain the appropriate lines with `Proceed.`
- ✅ With `--think-ultra-hard` (continue mode): Both prompts contain the appropriate lines with `Continue.`

All linting checks pass with no new errors.

Fixes #290

🤖 Generated with Claude Code (https://claude.ai/code)