### PR TITLE
Fix fork name parsing regression from PR #316

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/deep-assistant/hive-mind/issues/314
-Your prepared branch: issue-314-8d04dc50
-Your prepared working directory: /tmp/gh-issue-solver-1758969829906
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/deep-assistant/hive-mind/issues/314
+Your prepared branch: issue-314-8d04dc50
+Your prepared working directory: /tmp/gh-issue-solver-1758969829906
+
+Proceed.

--- a/experiments/test-fork-name-parsing.mjs
+++ b/experiments/test-fork-name-parsing.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+// Test fork name parsing from various gh repo fork outputs
+
+const testCases = [
+  'konard/Test_Canaan already exists',
+  'https://github.com/konard/Test_Canaan',
+  '✓ Created fork konard/netkeep80-jsonRVM',
+  'konard/jsonRVM',
+  '! konard/repo-name already exists on GitHub'
+];
+
+console.log('Testing fork name parsing\n');
+console.log('Current regex: ([a-zA-Z0-9_-]+\\/[a-zA-Z0-9_-]+)\n');
+
+testCases.forEach((output, i) => {
+  console.log(`Test ${i + 1}: "${output}"`);
+
+  // Current (broken) regex
+  const match1 = output.match(/([a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+)/);
+  console.log(`  Current regex match: ${match1 ? match1[1] : 'NO MATCH'}`);
+
+  // Better regex - match after github.com/ or at start of line
+  const match2 = output.match(/(?:github\.com\/|^|\s)([a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+)/);
+  console.log(`  Better regex match:  ${match2 ? match2[1] : 'NO MATCH'}`);
+
+  console.log();
+});

--- a/experiments/validate-fork-parsing-fix.mjs
+++ b/experiments/validate-fork-parsing-fix.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+
+console.log('='.repeat(80));
+console.log('FORK NAME PARSING VALIDATION');
+console.log('='.repeat(80));
+console.log();
+
+const testCases = [
+  {
+    name: 'URL format (new fork)',
+    output: 'https://github.com/konard/Test_Canaan',
+    expected: 'konard/Test_Canaan'
+  },
+  {
+    name: 'Already exists format',
+    output: 'konard/Test_Canaan already exists',
+    expected: 'konard/Test_Canaan'
+  },
+  {
+    name: 'Alternate fork name format',
+    output: 'konard/netkeep80-jsonRVM already exists',
+    expected: 'konard/netkeep80-jsonRVM'
+  },
+  {
+    name: 'Created fork message',
+    output: '✓ Created fork konard/repo-name',
+    expected: 'konard/repo-name'
+  },
+  {
+    name: 'URL with trailing content',
+    output: 'https://github.com/user_name/my-repo\n',
+    expected: 'user_name/my-repo'
+  },
+  {
+    name: 'Fork name with underscores and dashes',
+    output: 'user-name/repo_name already exists',
+    expected: 'user-name/repo_name'
+  }
+];
+
+// The fixed regex
+const fixedRegex = /(?:github\.com\/|^|\s)([a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+)/;
+
+let allPassed = true;
+
+testCases.forEach((test, i) => {
+  console.log(`Test ${i + 1}: ${test.name}`);
+  console.log(`  Input:    "${test.output}"`);
+  console.log(`  Expected: "${test.expected}"`);
+
+  const match = test.output.match(fixedRegex);
+  const result = match ? match[1] : null;
+
+  console.log(`  Got:      "${result}"`);
+
+  if (result === test.expected) {
+    console.log(`  ✅ PASS`);
+  } else {
+    console.log(`  ❌ FAIL`);
+    allPassed = false;
+  }
+  console.log();
+});
+
+console.log('='.repeat(80));
+if (allPassed) {
+  console.log('✅ ALL TESTS PASSED');
+} else {
+  console.log('❌ SOME TESTS FAILED');
+  process.exit(1);
+}
+console.log('='.repeat(80));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deep-assistant/hive-mind",
-  "version": "0.12.18",
+  "version": "0.12.19",
   "description": "AI-powered issue solver and hive mind for collaborative problem solving",
   "main": "src/hive.mjs",
   "type": "module",

--- a/src/solve.repository.lib.mjs
+++ b/src/solve.repository.lib.mjs
@@ -135,7 +135,8 @@ export const setupRepository = async (argv, owner, repo, forkOwner = null) => {
 
         // Parse actual fork name from output (e.g., "konard/netkeep80-jsonRVM already exists")
         // GitHub may create forks with modified names to avoid conflicts
-        const forkNameMatch = forkOutput.match(/([a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+)/);
+        // Use regex that won't match domain names like "github.com/user" -> "com/user"
+        const forkNameMatch = forkOutput.match(/(?:github\.com\/|^|\s)([a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+)/);
         if (forkNameMatch) {
           actualForkName = forkNameMatch[1];
         }


### PR DESCRIPTION
## Summary

Fixes the fork name parsing regression introduced in PR #316 that caused new fork creation to fail.

## Problem

After PR #316 was merged, attempting to create a new fork would fail with the error:
```
✅ Fork created: com/konard
🔍 Verifying fork: Checking accessibility...
❌ Error: Fork exists but not accessible after multiple retries
```

The fork name was being parsed incorrectly as `com/konard` instead of `konard/repo-name`.

## Root Cause

The regex pattern `/([a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+)/` would match the **first** occurrence of `something/something` in the gh repo fork output.

When `gh repo fork` creates a new fork, it outputs a URL like:
```
https://github.com/konard/Test_Canaan
```

The regex would incorrectly match `com/konard` from the URL instead of `konard/Test_Canaan`.

## Solution

Updated the regex to be more specific:
```javascript
/(?:github\.com\/|^|\s)([a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+)/
```

This matches fork names that appear:
- After `github.com/` in URLs
- At the start of a line
- After whitespace

Now correctly handles all fork output formats:
- ✅ `https://github.com/konard/Test_Canaan` → `konard/Test_Canaan`
- ✅ `konard/Test_Canaan already exists` → `konard/Test_Canaan`
- ✅ `✓ Created fork konard/repo` → `konard/repo`
- ✅ `konard/netkeep80-jsonRVM already exists` → `konard/netkeep80-jsonRVM`

## Testing

Added comprehensive test cases in `experiments/validate-fork-parsing-fix.mjs` covering all known fork output formats.

All tests pass:
```
Test 1: URL format (new fork) ✅
Test 2: Already exists format ✅
Test 3: Alternate fork name format ✅
Test 4: Created fork message ✅
Test 5: URL with trailing content ✅
Test 6: Fork name with underscores and dashes ✅
```

## Impact

This fix resolves both issues reported in #314:
1. ✅ New fork creation now works correctly
2. ✅ Existing fork detection continues to work

Fixes #314

🤖 Generated with [Claude Code](https://claude.ai/code)