### PR TITLE
Add system prompt guidance for handling screenshots and images

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/deep-assistant/hive-mind/issues/318
+Your prepared branch: issue-318-fe2cd23d
+Your prepared working directory: /tmp/gh-issue-solver-1759049960209
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/deep-assistant/hive-mind/issues/318
-Your prepared branch: issue-318-fe2cd23d
-Your prepared working directory: /tmp/gh-issue-solver-1759049960209
-
-Proceed.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deep-assistant/hive-mind",
-  "version": "0.12.19",
+  "version": "0.12.20",
   "description": "AI-powered issue solver and hive mind for collaborative problem solving",
   "main": "src/hive.mjs",
   "type": "module",

--- a/src/claude.prompts.lib.mjs
+++ b/src/claude.prompts.lib.mjs
@@ -108,7 +108,7 @@ General guidelines.
 
 Initial research.
    - When you read issue, read all details and comments thoroughly.
-   - When you see screenshots or images in issue descriptions, pull request descriptions, comments, or discussions, use appropriate tools to view and analyze them.
+   - When you see screenshots or images in issue descriptions, pull request descriptions, comments, or discussions, use WebFetch tool (or fetch tool) to download the image first, then use Read tool to view and analyze it.
    - When you need issue details, use gh issue view https://github.com/${owner}/${repo}/issues/${issueNumber}.
    - When you need related code, use gh search code --owner ${owner} [keywords].
    - When you need repo context, read files in your working directory.

--- a/src/claude.prompts.lib.mjs
+++ b/src/claude.prompts.lib.mjs
@@ -108,6 +108,7 @@ General guidelines.
 
 Initial research.
    - When you read issue, read all details and comments thoroughly.
+   - When you see screenshots or images in issue descriptions, pull request descriptions, comments, or discussions, use appropriate tools to view and analyze them.
    - When you need issue details, use gh issue view https://github.com/${owner}/${repo}/issues/${issueNumber}.
    - When you need related code, use gh search code --owner ${owner} [keywords].
    - When you need repo context, read files in your working directory.


### PR DESCRIPTION
## Summary

Added instruction to the system prompt to guide the AI to properly view and analyze screenshots or images found in issue descriptions, pull request descriptions, comments, or discussions.

## Changes

- Updated `src/claude.prompts.lib.mjs` to add a new guideline in the "Initial research" section
- Added: "When you see screenshots or images in issue descriptions, pull request descriptions, comments, or discussions, use appropriate tools to view and analyze them."

## Problem Solved

Previously, the AI would sometimes fail to access screenshots and make excuses like "I couldn't access the screenshot image directly." This guidance increases the probability that the AI will properly handle visual content on the first attempt.

## Test Plan

- [x] Added the guidance line following the "when x, do y" style as specified
- [x] Positioned it logically in the "Initial research" section after reading issue details
- [x] Verified the change integrates well with existing guidelines

Fixes #318

🤖 Generated with [Claude Code](https://claude.ai/code)