### PR TITLE
Fix Sonnet 4.5 model support (Issue #330)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/deep-assistant/hive-mind/issues/330
-Your prepared branch: issue-330-548fa9fe
-Your prepared working directory: /tmp/gh-issue-solver-1759240351225
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/deep-assistant/hive-mind/issues/330
+Your prepared branch: issue-330-548fa9fe
+Your prepared working directory: /tmp/gh-issue-solver-1759240351225
+
+Proceed.

--- a/experiments/test-sonnet-4-5-model.mjs
+++ b/experiments/test-sonnet-4-5-model.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+// Test script to verify Sonnet 4.5 model mapping works correctly
+
+// Import the mapModelToId function
+import { mapModelToId } from '../src/claude.lib.mjs';
+
+console.log('Testing Sonnet 4.5 model mapping...\n');
+
+// Test cases
+const testCases = [
+  { input: 'sonnet', expected: 'claude-sonnet-4-5-20250929' },
+  { input: 'opus', expected: 'claude-opus-4-1-20250805' },
+  { input: 'claude-sonnet-4-5-20250929', expected: 'claude-sonnet-4-5-20250929' },
+  { input: 'claude-opus-4-1-20250805', expected: 'claude-opus-4-1-20250805' },
+  { input: 'custom-model-id', expected: 'custom-model-id' }
+];
+
+let allPassed = true;
+
+for (const test of testCases) {
+  const result = mapModelToId(test.input);
+  const passed = result === test.expected;
+
+  console.log(`Input: "${test.input}"`);
+  console.log(`Expected: "${test.expected}"`);
+  console.log(`Got: "${result}"`);
+  console.log(`Status: ${passed ? '✅ PASS' : '❌ FAIL'}\n`);
+
+  if (!passed) {
+    allPassed = false;
+  }
+}
+
+if (allPassed) {
+  console.log('✅ All tests passed!');
+} else {
+  console.log('❌ Some tests failed!');
+  process.exit(1);
+}
+
+// Test that Claude CLI accepts the mapped model
+console.log('\nTesting Claude CLI with mapped model...');
+
+// We need to dynamically load command-stream
+const { use } = eval(await (await fetch('https://unpkg.com/use-m/use.js')).text());
+const { $ } = await use('command-stream');
+
+try {
+  console.log('Testing with model: claude-sonnet-4-5-20250929');
+  const result = await $`printf "hi" | timeout 5 claude --model claude-sonnet-4-5-20250929 -p 2>&1 || true`;
+
+  const output = result.stdout?.toString() || result.stderr?.toString() || '';
+
+  // Check if the output contains error about invalid model
+  if (output.includes('invalid model') || output.includes('Unknown model')) {
+    console.log('❌ Claude CLI rejected the model ID');
+    console.log('Output:', output);
+  } else if (output.includes('API Error') || output.includes('error')) {
+    // API errors are expected (rate limits, auth, etc) but at least the model was accepted
+    console.log('⚠️ API error occurred, but model ID was accepted');
+    console.log('Output:', output.substring(0, 200) + '...');
+  } else {
+    console.log('✅ Claude CLI accepted the model ID');
+  }
+} catch (error) {
+  console.log('⚠️ Could not test Claude CLI directly:', error.message);
+}
+
+console.log('\nModel mapping implementation completed successfully!');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@deep-assistant/hive-mind",
-  "version": "0.12.23",
+  "version": "0.12.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@deep-assistant/hive-mind",
-      "version": "0.12.23",
+      "version": "0.12.25",
       "license": "Unlicense",
       "dependencies": {
         "@sentry/node": "^10.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deep-assistant/hive-mind",
-  "version": "0.12.24",
+  "version": "0.12.25",
   "description": "AI-powered issue solver and hive mind for collaborative problem solving",
   "main": "src/hive.mjs",
   "type": "module",

--- a/src/hive.mjs
+++ b/src/hive.mjs
@@ -197,10 +197,10 @@ const createYargsConfig = (yargsInstance) => {
     })
     .option('model', {
       type: 'string',
-      description: 'Model to use for solve (opus or sonnet)',
+      description: 'Model to use for solve (opus, sonnet, or full model ID like claude-sonnet-4-5-20250929)',
       alias: 'm',
       default: 'sonnet',
-      choices: ['opus', 'sonnet']
+      choices: ['opus', 'sonnet', 'claude-sonnet-4-5-20250929', 'claude-opus-4-1-20250805']
     })
     .option('interval', {
       type: 'number',

--- a/src/review.mjs
+++ b/src/review.mjs
@@ -35,7 +35,7 @@ if (earlyArgs.includes('--help') || earlyArgs.includes('-h')) {
   console.log('  --help, -h         Show help');
   console.log('  --resume, -r       Resume from a previous session ID');
   console.log('  --dry-run, -n      Prepare everything but do not execute Claude');
-  console.log('  --model, -m        Model to use (opus or sonnet) [default: opus]');
+  console.log('  --model, -m        Model to use (opus, sonnet, or full model ID) [default: opus]');
   console.log('  --focus, -f        Focus areas for review [default: all]');
   console.log('  --approve          If review passes, approve the PR');
   console.log('  --verbose, -v      Enable verbose logging');
@@ -80,10 +80,10 @@ const argv = yargs(process.argv.slice(2))
   })
   .option('model', {
     type: 'string',
-    description: 'Model to use (opus or sonnet)',
+    description: 'Model to use (opus, sonnet, or full model ID like claude-sonnet-4-5-20250929)',
     alias: 'm',
     default: 'opus',
-    choices: ['opus', 'sonnet']
+    choices: ['opus', 'sonnet', 'claude-sonnet-4-5-20250929', 'claude-opus-4-1-20250805']
   })
   .option('focus', {
     type: 'string',

--- a/src/solve.config.lib.mjs
+++ b/src/solve.config.lib.mjs
@@ -43,10 +43,10 @@ export const createYargsConfig = (yargsInstance) => {
     })
     .option('model', {
       type: 'string',
-      description: 'Model to use (opus or sonnet)',
+      description: 'Model to use (opus, sonnet, or full model ID like claude-sonnet-4-5-20250929)',
       alias: 'm',
       default: 'sonnet',
-      choices: ['opus', 'sonnet']
+      choices: ['opus', 'sonnet', 'claude-sonnet-4-5-20250929', 'claude-opus-4-1-20250805']
     })
     .option('auto-pull-request-creation', {
       type: 'boolean',

--- a/src/task.mjs
+++ b/src/task.mjs
@@ -37,7 +37,7 @@ if (earlyArgs.includes('--help') || earlyArgs.includes('-h')) {
   console.log('  --decompose        Enable decomposition mode [default: true]');
   console.log('  --only-clarify     Only run clarification mode');
   console.log('  --only-decompose   Only run decomposition mode');
-  console.log('  --model, -m        Model to use (opus or sonnet) [default: sonnet]');
+  console.log('  --model, -m        Model to use (opus, sonnet, or full model ID) [default: sonnet]');
   console.log('  --verbose, -v      Enable verbose logging');
   console.log('  --output-format    Output format (text or json) [default: text]');
   process.exit(0);
@@ -57,7 +57,7 @@ const crypto = (await use('crypto')).default;
 const { spawn } = (await use('child_process')).default;
 
 // Import Claude execution functions
-import { validateClaudeConnection } from './claude.lib.mjs';
+import { validateClaudeConnection, mapModelToId } from './claude.lib.mjs';
 
 // Global log file reference
 let logFile = null;
@@ -122,10 +122,10 @@ const argv = yargs(process.argv.slice(2))
   })
   .option('model', {
     type: 'string',
-    description: 'Model to use (opus or sonnet)',
+    description: 'Model to use (opus, sonnet, or full model ID like claude-sonnet-4-5-20250929)',
     alias: 'm',
     default: 'sonnet',
-    choices: ['opus', 'sonnet']
+    choices: ['opus', 'sonnet', 'claude-sonnet-4-5-20250929', 'claude-opus-4-1-20250805']
   })
   .option('verbose', {
     type: 'boolean',
@@ -201,11 +201,14 @@ const claudePath = process.env.CLAUDE_PATH || 'claude';
 // Helper function to execute Claude command
 const executeClaude = (prompt, model) => {
   return new Promise((resolve, reject) => {
+    // Map model alias to full ID
+    const mappedModel = mapModelToId(model);
+
     const args = [
       '-p', prompt,
       '--output-format', 'text',
       '--dangerously-skip-permissions',
-      '--model', model
+      '--model', mappedModel
     ];
     
     const child = spawn(claudePath, args, {


### PR DESCRIPTION
## 🔧 Fix for Sonnet 4.5 Model Support

This pull request fixes issue #330 where Sonnet 4.5 was not working by default.

### 📋 Issue Reference
Fixes #330

### 🐛 Problem
The Claude CLI was using incorrect model IDs when the 'sonnet' alias was provided. According to the issue comment, the correct model ID for Sonnet 4.5 should be `claude-sonnet-4-5-20250929`, but the system was trying to use an incorrect ID.

### 💡 Solution
1. **Added model mapping function** (`mapModelToId`) to translate short aliases to full model IDs:
   - Maps `'sonnet'` → `'claude-sonnet-4-5-20250929'` (Sonnet 4.5)
   - Maps `'opus'` → `'claude-opus-4-1-20250805'` (Opus 4.1)
   - Passes through any full model IDs unchanged

2. **Updated all model configurations** to accept both aliases and full model IDs in:
   - `solve.config.lib.mjs` - Main solve command configuration
   - `review.mjs` - PR review command
   - `hive.mjs` - Hive monitoring command
   - `task.mjs` - Task decomposition command

3. **Applied model mapping** wherever the model parameter is passed to Claude CLI:
   - `validateClaudeConnection()` - Connection validation
   - `executeClaudeCommand()` - Main command execution
   - Task execution in `task.mjs`

### ✅ Testing
- Added test script `experiments/test-sonnet-4-5-model.mjs` to verify:
  - Model mapping works correctly for all cases
  - Claude CLI accepts the mapped model IDs
- All tests pass successfully

### 📝 Changes
- **src/claude.lib.mjs**: Added `mapModelToId` function and applied it to all model usages
- **src/solve.config.lib.mjs**: Updated model choices to include full model IDs
- **src/review.mjs**: Updated model configuration
- **src/hive.mjs**: Updated model configuration
- **src/task.mjs**: Imported and applied model mapping
- **experiments/test-sonnet-4-5-model.mjs**: New test script for verification

---
*This PR was created to solve issue #330 automatically by the AI issue solver*