### PR TITLE
fix: Include issue number in screen session name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/deep-assistant/hive-mind/issues/348
+Your prepared branch: issue-348-f4987c0b
+Your prepared working directory: /tmp/gh-issue-solver-1759299350461
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/deep-assistant/hive-mind/issues/348
-Your prepared branch: issue-348-f4987c0b
-Your prepared working directory: /tmp/gh-issue-solver-1759299350461
-
-Proceed.

--- a/experiments/test-screen-name-fix.mjs
+++ b/experiments/test-screen-name-fix.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+// Direct test of the fixed start-screen.mjs generateScreenName function
+
+// Load use-m dynamically from unpkg (same as start-screen.mjs)
+const { use } = eval(await (await fetch('https://unpkg.com/use-m/use.js')).text());
+
+// Dynamically load parse-github-url using use-m
+const parseGitHubUrlModule = await use('parse-github-url@1.0.3');
+const parseGitHubUrlLib = parseGitHubUrlModule.default || parseGitHubUrlModule;
+
+// Copy the FIXED parseGitHubUrl function from start-screen.mjs
+function parseGitHubUrl(url) {
+  if (!url || typeof url !== 'string') {
+    return {
+      valid: false,
+      error: 'Invalid input: URL must be a non-empty string'
+    };
+  }
+
+  try {
+    // Use parse-github-url library loaded via use-m
+    const parsed = parseGitHubUrlLib(url);
+
+    if (!parsed || !parsed.owner || !parsed.name) {
+      return {
+        valid: false,
+        error: 'Invalid GitHub URL: missing owner/repo'
+      };
+    }
+
+    const result = {
+      valid: true,
+      normalized: parsed.href || url,
+      hostname: parsed.host || 'github.com',
+      owner: parsed.owner,
+      repo: parsed.name,
+      type: 'unknown',
+      path: parsed.filepath || '',
+      number: null
+    };
+
+    // Determine the type based on branch and filepath
+    // Note: parse-github-url treats "issues" as a branch, not part of filepath
+    if (parsed.branch === 'issues' && parsed.filepath && /^\d+$/.test(parsed.filepath)) {
+      result.type = 'issue';
+      result.number = parseInt(parsed.filepath, 10);
+    } else if (parsed.branch === 'pull' && parsed.filepath && /^\d+$/.test(parsed.filepath)) {
+      result.type = 'pr';
+      result.number = parseInt(parsed.filepath, 10);
+    } else if (parsed.owner && parsed.name) {
+      result.type = 'repo';
+    } else if (parsed.owner) {
+      result.type = 'owner';
+    }
+
+    return result;
+  } catch (error) {
+    return {
+      valid: false,
+      error: 'Invalid GitHub URL format: ' + error.message
+    };
+  }
+}
+
+// Copy generateScreenName function from start-screen.mjs
+function generateScreenName(command, githubUrl) {
+  const parsed = parseGitHubUrl(githubUrl);
+
+  if (!parsed.valid) {
+    // Fallback to simple naming if parsing fails
+    const sanitized = githubUrl.replace(/[^a-zA-Z0-9-]/g, '-').substring(0, 30);
+    return `${command}-${sanitized}`;
+  }
+
+  // Build name parts
+  const parts = [command];
+
+  if (parsed.owner) {
+    parts.push(parsed.owner);
+  }
+
+  if (parsed.repo) {
+    parts.push(parsed.repo);
+  }
+
+  if (parsed.number) {
+    parts.push(parsed.number);
+  }
+
+  return parts.join('-');
+}
+
+// Test cases
+console.log('='.repeat(70));
+console.log('Testing FIXED start-screen.mjs logic');
+console.log('='.repeat(70));
+
+const testCases = [
+  {
+    command: 'solve',
+    url: 'https://github.com/veb86/zcadvelecAI/issues/19',
+    expected: 'solve-veb86-zcadvelecAI-19',
+    description: 'Issue #19 from the bug report'
+  },
+  {
+    command: 'solve',
+    url: 'https://github.com/deep-assistant/hive-mind/issues/348',
+    expected: 'solve-deep-assistant-hive-mind-348',
+    description: 'Current issue being fixed'
+  },
+  {
+    command: 'hive',
+    url: 'https://github.com/veb86/zcadvelecAI',
+    expected: 'hive-veb86-zcadvelecAI',
+    description: 'Repository without issue number'
+  },
+  {
+    command: 'solve',
+    url: 'https://github.com/openai/gpt-4/pull/100',
+    expected: 'solve-openai-gpt-4-100',
+    description: 'Pull request URL'
+  }
+];
+
+let allPassed = true;
+
+for (const testCase of testCases) {
+  const { command, url, expected, description } = testCase;
+  const result = generateScreenName(command, url);
+  const passed = result === expected;
+
+  if (!passed) allPassed = false;
+
+  console.log(`\n${passed ? '✓' : '✗'} ${description}`);
+  console.log(`  URL:      ${url}`);
+  console.log(`  Expected: ${expected}`);
+  console.log(`  Got:      ${result}`);
+
+  if (passed) {
+    console.log('  Status:   PASS');
+  } else {
+    console.log('  Status:   FAIL');
+  }
+}
+
+console.log('\n' + '='.repeat(70));
+if (allPassed) {
+  console.log('✓ All tests PASSED!');
+  process.exit(0);
+} else {
+  console.log('✗ Some tests FAILED!');
+  process.exit(1);
+}

--- a/experiments/test-screen-name-parsing.mjs
+++ b/experiments/test-screen-name-parsing.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+// Experiment to understand parse-github-url behavior and test the fix
+
+// Load use-m dynamically from unpkg
+const { use } = eval(await (await fetch('https://unpkg.com/use-m/use.js')).text());
+
+// Dynamically load parse-github-url using use-m
+const parseGitHubUrlModule = await use('parse-github-url@1.0.3');
+const parseGitHubUrlLib = parseGitHubUrlModule.default || parseGitHubUrlModule;
+
+console.log('='.repeat(60));
+console.log('Testing parse-github-url library behavior');
+console.log('='.repeat(60));
+
+const testUrls = [
+  'https://github.com/veb86/zcadvelecAI/issues/19',
+  'https://github.com/veb86/zcadvelecAI/pull/25',
+  'https://github.com/veb86/zcadvelecAI',
+];
+
+for (const url of testUrls) {
+  console.log(`\nURL: ${url}`);
+  const parsed = parseGitHubUrlLib(url);
+  console.log(`  branch: "${parsed.branch}"`);
+  console.log(`  filepath: "${parsed.filepath}"`);
+  console.log(`  owner: "${parsed.owner}"`);
+  console.log(`  name: "${parsed.name}"`);
+}
+
+console.log('\n' + '='.repeat(60));
+console.log('Testing current (BUGGY) parseGitHubUrl logic');
+console.log('='.repeat(60));
+
+function parseGitHubUrlBuggy(url) {
+  const parsed = parseGitHubUrlLib(url);
+
+  if (!parsed || !parsed.owner || !parsed.name) {
+    return { valid: false };
+  }
+
+  const result = {
+    valid: true,
+    owner: parsed.owner,
+    repo: parsed.name,
+    type: 'unknown',
+    number: null
+  };
+
+  // BUG: This checks filepath which is "19", not "issues/19"
+  if (parsed.filepath) {
+    const pathParts = parsed.filepath.split('/');
+
+    if (pathParts[0] === 'issues' && /^\d+$/.test(pathParts[1])) {
+      result.type = 'issue';
+      result.number = parseInt(pathParts[1], 10);
+    } else if (pathParts[0] === 'pull' && /^\d+$/.test(pathParts[1])) {
+      result.type = 'pr';
+      result.number = parseInt(pathParts[1], 10);
+    }
+  }
+
+  return result;
+}
+
+for (const url of testUrls) {
+  console.log(`\nURL: ${url}`);
+  const result = parseGitHubUrlBuggy(url);
+  console.log(`  type: ${result.type}, number: ${result.number}`);
+}
+
+console.log('\n' + '='.repeat(60));
+console.log('Testing FIXED parseGitHubUrl logic');
+console.log('='.repeat(60));
+
+function parseGitHubUrlFixed(url) {
+  const parsed = parseGitHubUrlLib(url);
+
+  if (!parsed || !parsed.owner || !parsed.name) {
+    return { valid: false };
+  }
+
+  const result = {
+    valid: true,
+    owner: parsed.owner,
+    repo: parsed.name,
+    type: 'unknown',
+    number: null
+  };
+
+  // FIX: Check the branch property for "issues" or "pull"
+  if (parsed.branch === 'issues' && parsed.filepath && /^\d+$/.test(parsed.filepath)) {
+    result.type = 'issue';
+    result.number = parseInt(parsed.filepath, 10);
+  } else if (parsed.branch === 'pull' && parsed.filepath && /^\d+$/.test(parsed.filepath)) {
+    result.type = 'pr';
+    result.number = parseInt(parsed.filepath, 10);
+  } else if (parsed.owner && parsed.name && !parsed.branch) {
+    result.type = 'repo';
+  }
+
+  return result;
+}
+
+for (const url of testUrls) {
+  console.log(`\nURL: ${url}`);
+  const result = parseGitHubUrlFixed(url);
+  console.log(`  type: ${result.type}, number: ${result.number}`);
+}
+
+console.log('\n' + '='.repeat(60));
+console.log('Testing screen name generation');
+console.log('='.repeat(60));
+
+function generateScreenName(command, githubUrl) {
+  const parsed = parseGitHubUrlFixed(githubUrl);
+
+  if (!parsed.valid) {
+    return `${command}-invalid`;
+  }
+
+  const parts = [command];
+
+  if (parsed.owner) {
+    parts.push(parsed.owner);
+  }
+
+  if (parsed.repo) {
+    parts.push(parsed.repo);
+  }
+
+  if (parsed.number) {
+    parts.push(parsed.number);
+  }
+
+  return parts.join('-');
+}
+
+console.log('\nCommand: solve');
+console.log('URL: https://github.com/veb86/zcadvelecAI/issues/19');
+console.log('Expected: solve-veb86-zcadvelecAI-19');
+console.log('Got:      ' + generateScreenName('solve', 'https://github.com/veb86/zcadvelecAI/issues/19'));
+
+console.log('\nCommand: solve');
+console.log('URL: https://github.com/veb86/zcadvelecAI');
+console.log('Expected: solve-veb86-zcadvelecAI');
+console.log('Got:      ' + generateScreenName('solve', 'https://github.com/veb86/zcadvelecAI'));
+
+console.log('\n' + '='.repeat(60));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deep-assistant/hive-mind",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "AI-powered issue solver and hive mind for collaborative problem solving",
   "main": "src/hive.mjs",
   "type": "module",

--- a/start-screen.mjs
+++ b/start-screen.mjs
@@ -44,17 +44,14 @@ function parseGitHubUrl(url) {
       number: null
     };
 
-    // Determine the type based on path structure
-    if (parsed.filepath) {
-      const pathParts = parsed.filepath.split('/');
-
-      if (pathParts[0] === 'issues' && /^\d+$/.test(pathParts[1])) {
-        result.type = 'issue';
-        result.number = parseInt(pathParts[1], 10);
-      } else if (pathParts[0] === 'pull' && /^\d+$/.test(pathParts[1])) {
-        result.type = 'pr';
-        result.number = parseInt(pathParts[1], 10);
-      }
+    // Determine the type based on branch and filepath
+    // Note: parse-github-url treats "issues" as a branch, not part of filepath
+    if (parsed.branch === 'issues' && parsed.filepath && /^\d+$/.test(parsed.filepath)) {
+      result.type = 'issue';
+      result.number = parseInt(parsed.filepath, 10);
+    } else if (parsed.branch === 'pull' && parsed.filepath && /^\d+$/.test(parsed.filepath)) {
+      result.type = 'pr';
+      result.number = parseInt(parsed.filepath, 10);
     } else if (parsed.owner && parsed.name) {
       result.type = 'repo';
     } else if (parsed.owner) {


### PR DESCRIPTION
## Summary

Fixed the screen session naming bug where issue numbers were not included in the session name.

**Before:** `solve-veb86-zcadvelecAI`  
**After:** `solve-veb86-zcadvelecAI-19`

## Root Cause

The `parseGitHubUrl` function in `start-screen.mjs` was using the `parse-github-url` npm library, which has a specific behavior:
- For issue URLs like `https://github.com/veb86/zcadvelecAI/issues/19`
- It sets `parsed.branch = "issues"` and `parsed.filepath = "19"`
- Not `parsed.filepath = "issues/19"` as the code expected

The original code tried to parse `filepath.split('/')` expecting `["issues", "19"]`, but actually got `["19"]`, causing the issue number check to fail.

## Solution

Updated the `parseGitHubUrl` function in `start-screen.mjs:47-59` to:
- Check `parsed.branch === 'issues'` instead of `pathParts[0] === 'issues'`
- Use `parsed.filepath` directly as the issue number
- Apply the same fix for pull request URLs

## Testing

✅ All existing tests pass  
✅ Created experiment scripts to validate the fix  
✅ Tested with the exact example from issue #348  

**Test Results:**
- Issue URL: `https://github.com/veb86/zcadvelecAI/issues/19` → `solve-veb86-zcadvelecAI-19` ✓
- Repo URL: `https://github.com/veb86/zcadvelecAI` → `solve-veb86-zcadvelecAI` ✓
- Pull URL: `https://github.com/openai/gpt-4/pull/100` → `solve-openai-gpt-4-100` ✓

## Files Changed

- `start-screen.mjs` - Fixed URL parsing logic
- `experiments/test-screen-name-parsing.mjs` - Root cause analysis
- `experiments/test-screen-name-fix.mjs` - Validation tests

Fixes #348

🤖 Generated with [Claude Code](https://claude.ai/code)