### PR TITLE
fix: Prevent start-screen from creating duplicate sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/deep-assistant/hive-mind/issues/350
+Your prepared branch: issue-350-25c61bdf
+Your prepared working directory: /tmp/gh-issue-solver-1759308672555
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/deep-assistant/hive-mind/issues/350
-Your prepared branch: issue-350-25c61bdf
-Your prepared working directory: /tmp/gh-issue-solver-1759308672555
-
-Proceed.

--- a/experiments/test-session-reuse.mjs
+++ b/experiments/test-session-reuse.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+async function cleanupScreenSession(sessionName) {
+  try {
+    await execAsync(`screen -S ${sessionName} -X quit`);
+  } catch (error) {
+  }
+}
+
+async function screenSessionExists(sessionName) {
+  try {
+    const { stdout } = await execAsync('screen -ls');
+    return stdout.includes(sessionName);
+  } catch (error) {
+    return false;
+  }
+}
+
+async function testSessionReuse() {
+  const testSessionName = 'solve-test-repo-1';
+
+  console.log('='.repeat(70));
+  console.log('Testing screen session reuse behavior');
+  console.log('='.repeat(70));
+  console.log();
+
+  try {
+    await cleanupScreenSession(testSessionName);
+
+    console.log('Step 1: Creating a dummy screen session...');
+    await execAsync(`screen -dmS ${testSessionName} bash -c 'echo "Test session"; exec bash'`);
+
+    const exists1 = await screenSessionExists(testSessionName);
+    console.log(`  Session exists: ${exists1 ? '✓ YES' : '✗ NO'}`);
+
+    if (!exists1) {
+      console.log('✗ FAILED: Could not create initial session');
+      process.exit(1);
+    }
+
+    console.log();
+    console.log('Step 2: Running start-screen with the same session name...');
+    console.log(`  Command: ./start-screen.mjs solve https://github.com/test/repo/issues/1`);
+    console.log();
+
+    const { stdout } = await execAsync(
+      `./start-screen.mjs solve https://github.com/test/repo/issues/1`,
+      { cwd: '/tmp/gh-issue-solver-1759308672555' }
+    );
+
+    console.log('Output from start-screen:');
+    console.log(stdout);
+
+    console.log('Step 3: Checking for duplicate sessions...');
+    const { stdout: screenList } = await execAsync('screen -ls');
+    const sessionMatches = screenList.match(new RegExp(testSessionName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'));
+    const count = sessionMatches ? sessionMatches.length : 0;
+
+    console.log(`  Sessions found with name pattern: ${count}`);
+
+    if (count > 1) {
+      console.log('  Screen list output:');
+      console.log(screenList);
+      console.log();
+      console.log('✗ FAILED: Multiple sessions with same name created');
+      await cleanupScreenSession(testSessionName);
+      process.exit(1);
+    }
+
+    console.log();
+    console.log('Step 4: Verifying output messages...');
+    const hasAlreadyExists = stdout.includes('already exists');
+    const hasReusing = stdout.includes('Reusing existing session');
+    const hasNoNewSession = !stdout.includes('Creating screen session');
+
+    console.log(`  Has "already exists" message: ${hasAlreadyExists ? '✓ YES' : '✗ NO'}`);
+    console.log(`  Has "Reusing existing session" message: ${hasReusing ? '✓ YES' : '✗ NO'}`);
+    console.log(`  Does NOT create new session: ${hasNoNewSession ? '✓ YES' : '✗ NO'}`);
+
+    const allChecks = hasAlreadyExists && hasReusing && hasNoNewSession;
+
+    console.log();
+    console.log('='.repeat(70));
+    if (allChecks && count === 1) {
+      console.log('✓ All tests PASSED!');
+      console.log('  - No duplicate sessions created');
+      console.log('  - Correct messages displayed');
+      await cleanupScreenSession(testSessionName);
+      process.exit(0);
+    } else {
+      console.log('✗ Some tests FAILED!');
+      await cleanupScreenSession(testSessionName);
+      process.exit(1);
+    }
+  } catch (error) {
+    console.error('Test error:', error.message);
+    await cleanupScreenSession(testSessionName);
+    process.exit(1);
+  }
+}
+
+testSessionReuse();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deep-assistant/hive-mind",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "AI-powered issue solver and hive mind for collaborative problem solving",
   "main": "src/hive.mjs",
   "type": "module",

--- a/start-screen.mjs
+++ b/start-screen.mjs
@@ -127,12 +127,14 @@ async function createOrEnterScreen(sessionName, command, args, autoTerminate = f
 
   if (sessionExists) {
     console.log(`Screen session '${sessionName}' already exists.`);
-    console.log('Creating new detached session with the command...');
-  } else {
-    console.log(`Creating screen session: ${sessionName}`);
+    console.log(`Reusing existing session instead of creating a new one.`);
+    console.log(`To attach to this session, run: screen -r ${sessionName}`);
+    return;
   }
 
-  // Always create a detached session with the command
+  console.log(`Creating screen session: ${sessionName}`);
+
+  // Create a detached session with the command
   // Quote arguments properly to preserve spaces and special characters
   const quotedArgs = args.map(arg => {
     // If arg contains spaces or special chars, wrap in single quotes


### PR DESCRIPTION
## Summary

Fixes #350 - `start-screen` now properly reuses existing screen sessions instead of creating duplicates with the same name.

## Problem

When running `start-screen` with a session name that already exists, the command would:
1. Detect the existing session and log "Screen session '...' already exists."
2. Then proceed to create a new detached session anyway with `screen -dmS`
3. GNU screen would automatically create a session with a modified name, leading to multiple sessions with similar names

This created confusion and made it difficult to manage screen sessions.

## Solution

Modified the `createOrEnterScreen` function in `start-screen.mjs` to:
- Check if a session with the target name already exists
- If it exists, print a message and instructions to attach to it, then exit early
- If it doesn't exist, proceed with creating the new session as before

## Changes

- **start-screen.mjs:125-176**: Added early return when session already exists instead of always creating a new session
- **experiments/test-session-reuse.mjs**: Added integration test to verify session reuse behavior

## Test Results

All existing tests pass:
✓ Screen name generation tests
✓ Help output tests
✓ Invalid command handling tests
✓ --auto-terminate flag tests

New integration test passes:
✓ Session reuse test - verifies no duplicates are created
✓ Correct messages displayed to user

## Behavior

**Before:**
```
$ start-screen solve https://github.com/user/repo/issues/21
Screen session 'solve-user-repo-21' already exists.
Creating new detached session with the command...
Started solve in detached screen session: solve-user-repo-21
$ screen -r solve-user-repo-21
There are several suitable screens on:
  1011154.solve-user-repo-21    (Detached)
  1004346.solve-user-repo-21    (Detached)
```

**After:**
```
$ start-screen solve https://github.com/user/repo/issues/21
Screen session 'solve-user-repo-21' already exists.
Reusing existing session instead of creating a new one.
To attach to this session, run: screen -r solve-user-repo-21
```

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>