### PR TITLE
fix: Remove non-existent telegraf version from use() call

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/deep-assistant/hive-mind/issues/365
-Your prepared branch: issue-365-cd406be6
-Your prepared working directory: /tmp/gh-issue-solver-1759367475076
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/deep-assistant/hive-mind/issues/365
+Your prepared branch: issue-365-cd406be6
+Your prepared working directory: /tmp/gh-issue-solver-1759367475076
+
+Proceed.

--- a/experiments/test-telegraf-load.mjs
+++ b/experiments/test-telegraf-load.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+// Test script to verify telegraf loads correctly with use-m
+
+if (typeof use === 'undefined') {
+  globalThis.use = (await eval(await (await fetch('https://unpkg.com/use-m/use.js')).text())).use;
+}
+
+console.log('Testing telegraf loading with use-m...');
+
+try {
+  const telegrafModule = await use('telegraf');
+  const { Telegraf } = telegrafModule;
+
+  console.log('✅ Successfully loaded telegraf');
+  console.log('Telegraf constructor:', typeof Telegraf);
+
+  // Test creating a bot instance with a fake token
+  const testBot = new Telegraf('test-token');
+  console.log('✅ Successfully created Telegraf instance');
+  console.log('Test completed successfully!');
+} catch (error) {
+  console.error('❌ Error loading telegraf:', error);
+  process.exit(1);
+}

--- a/experiments/test-telegram-bot-init.mjs
+++ b/experiments/test-telegram-bot-init.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+// Test script to verify telegram-bot initializes correctly
+
+console.log('Testing telegram-bot initialization...');
+
+// Mock process.exit to prevent the script from exiting
+const originalExit = process.exit;
+let exitCalled = false;
+process.exit = (code) => {
+  exitCalled = true;
+  console.log(`process.exit(${code}) was called`);
+  // Don't actually exit during test
+};
+
+// Import the telegram-bot module
+try {
+  // We'll test by checking if the module can be loaded
+  console.log('Attempting to load telegram-bot module...');
+
+  // Set a fake token to prevent early exit
+  process.env.TELEGRAM_BOT_TOKEN = 'test-fake-token-123';
+
+  // Load the module by importing it
+  // Note: This will start the bot, so we'll need to handle that
+  const { spawn } = await import('child_process');
+
+  // Instead, let's just check if the file parses correctly
+  const { readFile } = await import('fs/promises');
+  const content = await readFile('./src/telegram-bot.mjs', 'utf-8');
+
+  console.log('✅ telegram-bot.mjs file is readable');
+  console.log('✅ File contains', content.split('\n').length, 'lines');
+
+  // Check for the fix
+  if (content.includes("await use('telegraf')") && !content.includes("await use('telegraf@4.12.3')")) {
+    console.log('✅ Fix verified: Using telegraf without version specification');
+  } else {
+    console.log('❌ Fix not found: Still using versioned telegraf');
+    process.exit(1);
+  }
+
+  console.log('Test completed successfully!');
+} catch (error) {
+  console.error('❌ Error during test:', error);
+  process.exit(1);
+} finally {
+  process.exit = originalExit;
+}

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
   "dependencies": {
     "@sentry/node": "^10.15.0",
     "@sentry/profiling-node": "^10.15.0",
-    "telegraf": "^4.12.3"
+    "telegraf": "^4.16.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deep-assistant/hive-mind",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "AI-powered issue solver and hive mind for collaborative problem solving",
   "main": "src/hive.mjs",
   "type": "module",
@@ -48,7 +48,6 @@
   },
   "dependencies": {
     "@sentry/node": "^10.15.0",
-    "@sentry/profiling-node": "^10.15.0",
-    "telegraf": "^4.16.3"
+    "@sentry/profiling-node": "^10.15.0"
   }
 }

--- a/src/telegram-bot.mjs
+++ b/src/telegram-bot.mjs
@@ -42,7 +42,7 @@ if (!BOT_TOKEN) {
   process.exit(1);
 }
 
-const telegrafModule = await use('telegraf@4.12.3');
+const telegrafModule = await use('telegraf');
 const { Telegraf } = telegrafModule;
 
 const bot = new Telegraf(BOT_TOKEN);


### PR DESCRIPTION
## Summary

Fixed the `hive-telegram-bot` command which was failing due to attempting to install a non-existent telegraf version.

## Root Cause

- The code was trying to load `telegraf@4.12.3` using `use('telegraf@4.12.3')`
- Version 4.12.3 of telegraf **does not exist** in the npm registry
- The versions jump from 4.12.2 → 4.12.3-canary.1 → 4.13.0
- This caused the installation to fail with error: `No matching version found for telegraf@4.12.3`

## Changes Made

1. **src/telegram-bot.mjs**: Changed `await use('telegraf@4.12.3')` to `await use('telegraf')`
   - This allows use-m to load telegraf without specifying a version
   - The use-m library handles version resolution automatically

2. **package.json**: 
   - Removed telegraf from dependencies (use-m doesn't require it to be listed)
   - Bumped version from 0.18.0 to 0.18.1

3. **Added test scripts** in experiments/ folder to verify the fix works correctly

## Testing

Created and ran test scripts to verify:
- ✅ Telegraf loads correctly with use-m without version specification
- ✅ The fix is properly applied in the telegram-bot.mjs file
- ✅ All changes committed successfully

## Fixes

Fixes #365

---

🤖 Generated with [Claude Code](https://claude.ai/code)