### PR TITLE
fix: Replace .text() with correct command-stream API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/deep-assistant/hive-mind/issues/367
+Your prepared branch: issue-367-e904e743
+Your prepared working directory: /tmp/gh-issue-solver-1759369169443
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/deep-assistant/hive-mind/issues/367
-Your prepared branch: issue-367-e904e743
-Your prepared working directory: /tmp/gh-issue-solver-1759369169443
-
-Proceed.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deep-assistant/hive-mind",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "AI-powered issue solver and hive mind for collaborative problem solving",
   "main": "src/hive.mjs",
   "type": "module",

--- a/src/telegram-bot.mjs
+++ b/src/telegram-bot.mjs
@@ -79,18 +79,26 @@ async function executeStartScreen(command, args) {
 
     console.log(`Executing: ${fullCommand}`);
 
-    const result = await $`${fullCommand}`.text();
+    const commandResult = await $`${fullCommand}`;
 
-    return {
-      success: true,
-      output: result
-    };
+    if (commandResult.code === 0) {
+      return {
+        success: true,
+        output: commandResult.stdout.toString()
+      };
+    } else {
+      return {
+        success: false,
+        output: commandResult.stdout.toString(),
+        error: commandResult.stderr.toString()
+      };
+    }
   } catch (error) {
     console.error('Error executing start-screen:', error);
     return {
       success: false,
-      output: error.stdout || '',
-      error: error.stderr || error.message
+      output: error.stdout ? error.stdout.toString() : '',
+      error: error.stderr ? error.stderr.toString() : error.message
     };
   }
 }


### PR DESCRIPTION
## Summary

Fixed `TypeError: $(...).text is not a function` in the telegram-bot by using the correct command-stream API.

## Issue

Fixes #367

## Problem

The `executeStartScreen` function in `src/telegram-bot.mjs` was incorrectly calling `.text()` on the result of command-stream's `$` function, which doesn't have that method.

## Solution

Updated the function to use the correct command-stream API:
- Access `stdout` property via `commandResult.stdout.toString()` instead of calling `.text()`
- Check `commandResult.code` to determine success/failure (0 = success)
- Access `commandResult.stderr.toString()` for error messages

## Changes

- Modified `executeStartScreen` function to properly handle command-stream result object
- Added proper exit code checking
- Improved error handling to safely convert buffers to strings

## Testing

The fix follows the same pattern used throughout the codebase in files like:
- `src/hive.mjs` (line 616-618)
- `tests/test-feedback-lines.mjs` (line 69-71)

🤖 Generated with [Claude Code](https://claude.com/claude-code)