### PR TITLE
fix: Correct /help command descriptions for --think and --auto-continue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/deep-assistant/hive-mind/issues/373
-Your prepared branch: issue-373-0d22433f
-Your prepared working directory: /tmp/gh-issue-solver-1759417287807
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/deep-assistant/hive-mind/issues/373
+Your prepared branch: issue-373-0d22433f
+Your prepared working directory: /tmp/gh-issue-solver-1759417287807
+
+Proceed.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deep-assistant/hive-mind",
-  "version": "0.18.4",
+  "version": "0.18.5",
   "description": "AI-powered issue solver and hive mind for collaborative problem solving",
   "main": "src/hive.mjs",
   "type": "module",

--- a/src/telegram-bot.mjs
+++ b/src/telegram-bot.mjs
@@ -181,11 +181,11 @@ bot.command('help', async (ctx) => {
   message += `⚠️ *Note:* /solve and /hive commands only work in group chats.\n\n`;
   message += `🔧 *Available Options:*\n`;
   message += `• \`--fork\` - Fork the repository\n`;
-  message += `• \`--auto-continue\` - Auto-continue on feedback\n`;
+  message += `• \`--auto-continue\` - Continue working on existing pull request to the issue, if exists\n`;
   message += `• \`--attach-logs\` - Attach logs to PR\n`;
   message += `• \`--verbose\` - Verbose output\n`;
   message += `• \`--model <model>\` - Specify AI model (sonnet/opus/haiku)\n`;
-  message += `• \`--think <level>\` - Thinking level (max/medium/min)\n`;
+  message += `• \`--think <level>\` - Thinking level (low/medium/high/max)\n`;
 
   if (allowedChats) {
     message += `\n🔒 *Restricted Mode:* This bot only accepts commands from authorized chats.\n`;


### PR DESCRIPTION
## Summary

Fixed two bugs in the Telegram bot's `/help` command that had incorrect option descriptions:

• Fixed `--think` levels from incorrect `max/medium/min` to correct `low/medium/high/max` (matching the actual implementation in src/solve.config.lib.mjs:130 and src/hive.mjs:325)
• Fixed `--auto-continue` description from misleading "Auto-continue on feedback" to accurate "Continue working on existing pull request to the issue, if exists" (matching the actual behavior in src/solve.auto-continue.lib.mjs)

## Changes

- Updated line 184 in `src/telegram-bot.mjs` to fix `--auto-continue` description
- Updated line 188 in `src/telegram-bot.mjs` to fix `--think` levels

## Test Plan

- [x] Verified syntax is correct (node -c passed)
- [x] Confirmed descriptions match actual implementation in source code
- [x] Reviewed against issue requirements

Fixes #373

🤖 Generated with [Claude Code](https://claude.ai/code)