### PR TITLE
Fix: Add support for --no-tool-check flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/deep-assistant/hive-mind/issues/418
-Your prepared branch: issue-418-fb03b009
-Your prepared working directory: /tmp/gh-issue-solver-1759583126523
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/deep-assistant/hive-mind/issues/418
+Your prepared branch: issue-418-fb03b009
+Your prepared working directory: /tmp/gh-issue-solver-1759583126523
+
+Proceed.

--- a/experiments/test-tool-check-flag.mjs
+++ b/experiments/test-tool-check-flag.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+
+// Test to verify --no-tool-check works using the toolCheck option approach
+
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Test the solve.config.lib.mjs directly
+const use = (await eval(await (await fetch('https://unpkg.com/use-m/use.js')).text())).use;
+globalThis.use = use;
+
+const config = await import('../src/solve.config.lib.mjs');
+const { initializeConfig, createYargsConfig } = config;
+const { yargs, hideBin } = await initializeConfig(use);
+
+console.log('🧪 Testing --no-tool-check with tool-check option\n');
+
+// Test 1: Default - no flags (toolCheck should be true by default)
+console.log('Test 1: No flags (default)');
+try {
+  const argv1 = await createYargsConfig(yargs()).strict(false).demandCommand(0).parse(['https://github.com/test/repo/issues/1']);
+  console.log('   toolCheck:', argv1.toolCheck);
+  console.log('   skipToolCheck:', argv1.skipToolCheck);
+  const skip1 = argv1.dryRun || argv1.skipToolCheck || !argv1.toolCheck;
+  console.log('   Would skip tool check:', skip1);
+  if (skip1 === false) {
+    console.log('✅ Default behavior: tool check is performed\n');
+  } else {
+    console.log('❌ Default behavior broken\n');
+  }
+} catch (error) {
+  console.log('Error:', error.message, '\n');
+}
+
+// Test 2: With --no-tool-check (toolCheck should be false)
+console.log('Test 2: With --no-tool-check');
+try {
+  const argv2 = await createYargsConfig(yargs()).strict(false).demandCommand(0).parse(['https://github.com/test/repo/issues/1', '--no-tool-check']);
+  console.log('   toolCheck:', argv2.toolCheck);
+  console.log('   skipToolCheck:', argv2.skipToolCheck);
+  const skip2 = argv2.dryRun || argv2.skipToolCheck || !argv2.toolCheck;
+  console.log('   Would skip tool check:', skip2);
+  if (skip2 === true) {
+    console.log('✅ --no-tool-check works: tool check is skipped\n');
+  } else {
+    console.log('❌ --no-tool-check does NOT work\n');
+  }
+} catch (error) {
+  console.log('Error:', error.message, '\n');
+}
+
+// Test 3: With --skip-tool-check (should still work)
+console.log('Test 3: With --skip-tool-check');
+try {
+  const argv3 = await createYargsConfig(yargs()).strict(false).demandCommand(0).parse(['https://github.com/test/repo/issues/1', '--skip-tool-check']);
+  console.log('   toolCheck:', argv3.toolCheck);
+  console.log('   skipToolCheck:', argv3.skipToolCheck);
+  const skip3 = argv3.dryRun || argv3.skipToolCheck || !argv3.toolCheck;
+  console.log('   Would skip tool check:', skip3);
+  if (skip3 === true) {
+    console.log('✅ --skip-tool-check still works\n');
+  } else {
+    console.log('❌ --skip-tool-check broken\n');
+  }
+} catch (error) {
+  console.log('Error:', error.message, '\n');
+}
+
+// Test 4: With --tool-check (explicit enable, should override any skip)
+console.log('Test 4: With --tool-check (explicit enable)');
+try {
+  const argv4 = await createYargsConfig(yargs()).strict(false).demandCommand(0).parse(['https://github.com/test/repo/issues/1', '--tool-check']);
+  console.log('   toolCheck:', argv4.toolCheck);
+  console.log('   skipToolCheck:', argv4.skipToolCheck);
+  const skip4 = argv4.dryRun || argv4.skipToolCheck || !argv4.toolCheck;
+  console.log('   Would skip tool check:', skip4);
+  if (skip4 === false) {
+    console.log('✅ --tool-check works: tool check is performed\n');
+  } else {
+    console.log('❌ --tool-check does NOT work\n');
+  }
+} catch (error) {
+  console.log('Error:', error.message, '\n');
+}
+
+console.log('✨ All tests completed!');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deep-assistant/hive-mind",
-  "version": "0.21.5",
+  "version": "0.21.6",
   "description": "AI-powered issue solver and hive mind for collaborative problem solving",
   "main": "src/hive.mjs",
   "type": "module",

--- a/src/hive.mjs
+++ b/src/hive.mjs
@@ -238,6 +238,12 @@ const createYargsConfig = (yargsInstance) => {
       description: 'Skip tool connection check (useful in CI environments)',
       default: false
     })
+    .option('tool-check', {
+      type: 'boolean',
+      description: 'Perform tool connection check (enabled by default, use --no-tool-check to skip)',
+      default: true,
+      hidden: true
+    })
     .option('tool', {
       type: 'string',
       description: 'AI tool to use for solving issues',
@@ -790,7 +796,7 @@ async function worker(workerId) {
         const targetBranchFlag = argv.targetBranch ? ` --target-branch ${argv.targetBranch}` : '';
         const logDirFlag = argv.logDir ? ` --log-dir "${argv.logDir}"` : '';
         const dryRunFlag = argv.dryRun ? ' --dry-run' : '';
-        const skipToolCheckFlag = argv.skipToolCheck ? ' --skip-tool-check' : '';
+        const skipToolCheckFlag = (argv.skipToolCheck || !argv.toolCheck) ? ' --skip-tool-check' : '';
         const toolFlag = argv.tool ? ` --tool ${argv.tool}` : '';
         const autoContinueFlag = argv.autoContinue ? ' --auto-continue' : '';
         const thinkFlag = argv.think ? ` --think ${argv.think}` : '';
@@ -823,7 +829,7 @@ async function worker(workerId) {
         if (argv.dryRun) {
           args.push('--dry-run');
         }
-        if (argv.skipToolCheck) {
+        if (argv.skipToolCheck || !argv.toolCheck) {
           args.push('--skip-tool-check');
         }
         if (argv.autoContinue) {

--- a/src/solve.config.lib.mjs
+++ b/src/solve.config.lib.mjs
@@ -41,6 +41,12 @@ export const createYargsConfig = (yargsInstance) => {
       description: 'Skip tool connection check (useful in CI environments)',
       default: false
     })
+    .option('tool-check', {
+      type: 'boolean',
+      description: 'Perform tool connection check (enabled by default, use --no-tool-check to skip)',
+      default: true,
+      hidden: true
+    })
     .option('model', {
       type: 'string',
       description: 'Model to use (for claude: opus, sonnet; for opencode: grok, gpt4o, etc.)',

--- a/src/solve.mjs
+++ b/src/solve.mjs
@@ -173,8 +173,8 @@ if (!(await validateContinueOnlyOnFeedback(argv, isPrUrl, isIssueUrl))) {
   await safeExit(1, 'Feedback validation failed');
 }
 // Perform all system checks using validation module
-// Skip tool validation in dry-run mode or when --skip-tool-check is enabled
-const skipToolCheck = argv.dryRun || argv.skipToolCheck;
+// Skip tool validation in dry-run mode or when --skip-tool-check or --no-tool-check is enabled
+const skipToolCheck = argv.dryRun || argv.skipToolCheck || !argv.toolCheck;
 if (!(await performSystemChecks(argv.minDiskSpace || 500, skipToolCheck, argv.model, argv))) {
   await safeExit(1, 'System checks failed');
 }


### PR DESCRIPTION
## Summary

This PR fixes issue #418 where the `--no-tool-check` flag wasn't working for the `solve` and `hive` commands.

## Problem

The user tried to use `--no-tool-check` flag but it didn't work because:
- The actual flag name was `--skip-tool-check`
- Yargs treats `--no-*` as negation prefixes for boolean options
- Simply adding `--no-tool-check` as a separate option didn't work due to yargs' special handling

## Solution

To support the `--no-tool-check` flag, we:

1. **Added a hidden `--tool-check` option** (default: `true`) to both `solve` and `hive` commands
2. **Updated the logic** to check `!argv.toolCheck` when `--no-tool-check` is used
3. **Maintained backward compatibility** with `--skip-tool-check`

## Changes

- `src/solve.config.lib.mjs`: Added hidden `tool-check` option with default value `true`
- `src/hive.mjs`: Added hidden `tool-check` option and updated flag checks to include `!argv.toolCheck`
- `src/solve.mjs`: Updated `skipToolCheck` logic to include `!argv.toolCheck`
- `experiments/test-tool-check-flag.mjs`: Added comprehensive test suite
- `package.json`: Bumped version to 0.21.6

## Testing

Created comprehensive test suite (`experiments/test-tool-check-flag.mjs`) that verifies:

✅ Default behavior (tool check is performed)
✅ `--no-tool-check` flag works (tool check is skipped)
✅ `--skip-tool-check` flag still works (tool check is skipped)
✅ `--tool-check` flag works (tool check is performed)

## Behavior

Now both flags work correctly:

- `solve <url> --no-tool-check` → skips tool validation
- `solve <url> --skip-tool-check` → skips tool validation (backward compatible)
- `solve <url>` → performs tool validation (default)

This works for both `claude` and `opencode` tools as requested in the issue.

## Test Results

All tests pass successfully:
```
🧪 Testing --no-tool-check with tool-check option

Test 1: No flags (default)
   toolCheck: true
   skipToolCheck: false
   Would skip tool check: false
✅ Default behavior: tool check is performed

Test 2: With --no-tool-check
   toolCheck: false
   skipToolCheck: false
   Would skip tool check: true
✅ --no-tool-check works: tool check is skipped

Test 3: With --skip-tool-check
   toolCheck: true
   skipToolCheck: true
   Would skip tool check: true
✅ --skip-tool-check still works

Test 4: With --tool-check (explicit enable)
   toolCheck: true
   skipToolCheck: false
   Would skip tool check: false
✅ --tool-check works: tool check is performed
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)