### PR TITLE
feat: Add telegram bot options override functionality

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,8 @@ TELEGRAM_BOT_TOKEN=your_bot_token_here
 # )"
 # TELEGRAM_HIVE_OVERRIDES=
 
-# Optional: Disable specific commands
-# TELEGRAM_NO_SOLVE=false
-# TELEGRAM_NO_HIVE=false
+# Optional: Enable/disable specific commands (default: true)
+# Set to false to disable a command
+# Note: When using CLI, you can use --no-solve or --no-hive for disabling
+# TELEGRAM_SOLVE=true
+# TELEGRAM_HIVE=true

--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,27 @@ TELEGRAM_BOT_TOKEN=your_bot_token_here
 #   987654321
 # )"
 # TELEGRAM_ALLOWED_CHATS=
+
+# Optional: Override options for /solve command in lino notation
+# These options will be locked and override any user-provided values
+# Example:
+# TELEGRAM_SOLVE_OVERRIDES="(
+#   --auto-continue
+#   --attach-logs
+#   --verbose
+#   --tool opencode
+# )"
+# TELEGRAM_SOLVE_OVERRIDES=
+
+# Optional: Override options for /hive command in lino notation
+# Example:
+# TELEGRAM_HIVE_OVERRIDES="(
+#   --verbose
+#   --all-issues
+#   --model sonnet
+# )"
+# TELEGRAM_HIVE_OVERRIDES=
+
+# Optional: Disable specific commands
+# TELEGRAM_NO_SOLVE=false
+# TELEGRAM_NO_HIVE=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/deep-assistant/hive-mind/issues/434
-Your prepared branch: issue-434-42d6b305
-Your prepared working directory: /tmp/gh-issue-solver-1759658250460
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/deep-assistant/hive-mind/issues/434
+Your prepared branch: issue-434-42d6b305
+Your prepared working directory: /tmp/gh-issue-solver-1759658250460
+
+Proceed.

--- a/examples/test-telegram-bot-overrides.mjs
+++ b/examples/test-telegram-bot-overrides.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+
+/**
+ * Test script for telegram bot options override functionality
+ *
+ * Tests:
+ * 1. mergeArgsWithOverrides function with boolean flags
+ * 2. mergeArgsWithOverrides function with duplet flags (flag + value)
+ * 3. Proper removal of conflicting user args
+ * 4. Handling of multiple overrides
+ */
+
+import { strict as assert } from 'assert';
+
+// Mock the mergeArgsWithOverrides function
+function mergeArgsWithOverrides(userArgs, overrides) {
+  if (!overrides || overrides.length === 0) {
+    return userArgs;
+  }
+
+  // Parse overrides to identify flags and their values
+  const overrideFlags = new Map(); // Map of flag -> value (or null for boolean flags)
+
+  for (let i = 0; i < overrides.length; i++) {
+    const arg = overrides[i];
+    if (arg.startsWith('--')) {
+      // Check if next item is a value (doesn't start with --)
+      if (i + 1 < overrides.length && !overrides[i + 1].startsWith('--')) {
+        overrideFlags.set(arg, overrides[i + 1]);
+        i++; // Skip the value in next iteration
+      } else {
+        overrideFlags.set(arg, null); // Boolean flag
+      }
+    }
+  }
+
+  // Filter user args to remove any that conflict with overrides
+  const filteredArgs = [];
+  for (let i = 0; i < userArgs.length; i++) {
+    const arg = userArgs[i];
+    if (arg.startsWith('--')) {
+      // If this flag exists in overrides, skip it and its value
+      if (overrideFlags.has(arg)) {
+        // Skip the flag
+        // Also skip next arg if it's a value (doesn't start with --)
+        if (i + 1 < userArgs.length && !userArgs[i + 1].startsWith('--')) {
+          i++; // Skip the value too
+        }
+        continue;
+      }
+    }
+    filteredArgs.push(arg);
+  }
+
+  // Merge: filtered user args + overrides
+  return [...filteredArgs, ...overrides];
+}
+
+// Test cases
+const tests = [
+  {
+    name: 'No overrides - returns user args unchanged',
+    userArgs: ['https://github.com/owner/repo/issues/123', '--verbose', '--fork'],
+    overrides: [],
+    expected: ['https://github.com/owner/repo/issues/123', '--verbose', '--fork']
+  },
+  {
+    name: 'Boolean flag override - removes user flag',
+    userArgs: ['https://github.com/owner/repo/issues/123', '--verbose'],
+    overrides: ['--auto-continue'],
+    expected: ['https://github.com/owner/repo/issues/123', '--verbose', '--auto-continue']
+  },
+  {
+    name: 'Duplet override - removes user duplet',
+    userArgs: ['https://github.com/owner/repo/issues/123', '--tool', 'haiku'],
+    overrides: ['--tool', 'opencode'],
+    expected: ['https://github.com/owner/repo/issues/123', '--tool', 'opencode']
+  },
+  {
+    name: 'Multiple overrides with mixed types',
+    userArgs: ['https://github.com/owner/repo/issues/123', '--verbose', '--tool', 'haiku', '--fork'],
+    overrides: ['--auto-continue', '--attach-logs', '--tool', 'opencode'],
+    expected: ['https://github.com/owner/repo/issues/123', '--verbose', '--fork', '--auto-continue', '--attach-logs', '--tool', 'opencode']
+  },
+  {
+    name: 'Override replaces existing flag',
+    userArgs: ['https://github.com/owner/repo/issues/123', '--auto-continue', '--verbose'],
+    overrides: ['--auto-continue'],
+    expected: ['https://github.com/owner/repo/issues/123', '--verbose', '--auto-continue']
+  },
+  {
+    name: 'Multiple duplets with same flag',
+    userArgs: ['https://github.com/owner/repo/issues/123', '--model', 'haiku', '--verbose'],
+    overrides: ['--model', 'sonnet', '--think', 'max'],
+    expected: ['https://github.com/owner/repo/issues/123', '--verbose', '--model', 'sonnet', '--think', 'max']
+  },
+  {
+    name: 'Complex real-world scenario',
+    userArgs: ['https://github.com/owner/repo/issues/123', '--fork', '--model', 'haiku', '--verbose'],
+    overrides: ['--auto-continue', '--attach-logs', '--verbose', '--tool', 'opencode'],
+    expected: ['https://github.com/owner/repo/issues/123', '--fork', '--model', 'haiku', '--auto-continue', '--attach-logs', '--verbose', '--tool', 'opencode']
+  },
+  {
+    name: 'URL preserved as first argument',
+    userArgs: ['https://github.com/owner/repo/issues/123'],
+    overrides: ['--auto-continue', '--verbose'],
+    expected: ['https://github.com/owner/repo/issues/123', '--auto-continue', '--verbose']
+  }
+];
+
+let passed = 0;
+let failed = 0;
+
+console.log('🧪 Running telegram bot override tests...\n');
+
+for (const test of tests) {
+  try {
+    const result = mergeArgsWithOverrides(test.userArgs, test.overrides);
+    assert.deepEqual(result, test.expected);
+    console.log(`✅ PASS: ${test.name}`);
+    passed++;
+  } catch (error) {
+    console.error(`❌ FAIL: ${test.name}`);
+    console.error(`   Expected: ${JSON.stringify(test.expected)}`);
+    console.error(`   Got:      ${JSON.stringify(mergeArgsWithOverrides(test.userArgs, test.overrides))}`);
+    failed++;
+  }
+}
+
+console.log(`\n📊 Test Results: ${passed} passed, ${failed} failed`);
+
+if (failed > 0) {
+  process.exit(1);
+}
+
+console.log('✅ All tests passed!');

--- a/experiments/test-positive-form-options.mjs
+++ b/experiments/test-positive-form-options.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+/**
+ * Test script for positive form options (--solve/--hive instead of --no-solve/--no-hive)
+ */
+
+if (typeof use === 'undefined') {
+  globalThis.use = (await eval(await (await fetch('https://unpkg.com/use-m/use.js')).text())).use;
+}
+
+const yargsModule = await use('yargs@17.7.2');
+const yargs = yargsModule.default || yargsModule;
+
+console.log('Testing positive form options with yargs auto-negation...\n');
+
+function createParser(args) {
+  return yargs(args)
+    .option('solve', {
+      type: 'boolean',
+      description: 'Enable /solve command',
+      default: true
+    })
+    .option('hive', {
+      type: 'boolean',
+      description: 'Enable /hive command',
+      default: true
+    });
+}
+
+// Test 1: Default values (should be true)
+console.log('Test 1: Default values');
+const argv1 = createParser([]).parseSync();
+console.log(`  solve: ${argv1.solve} (expected: true)`);
+console.log(`  hive: ${argv1.hive} (expected: true)`);
+console.log(`  ✅ ${argv1.solve === true && argv1.hive === true ? 'PASS' : 'FAIL'}\n`);
+
+// Test 2: Explicit --solve and --hive
+console.log('Test 2: Explicit --solve and --hive');
+const argv2 = createParser(['--solve', '--hive']).parseSync();
+console.log(`  solve: ${argv2.solve} (expected: true)`);
+console.log(`  hive: ${argv2.hive} (expected: true)`);
+console.log(`  ✅ ${argv2.solve === true && argv2.hive === true ? 'PASS' : 'FAIL'}\n`);
+
+// Test 3: Auto-negation with --no-solve and --no-hive
+console.log('Test 3: Auto-negation with --no-solve and --no-hive');
+const argv3 = createParser(['--no-solve', '--no-hive']).parseSync();
+console.log(`  solve: ${argv3.solve} (expected: false)`);
+console.log(`  hive: ${argv3.hive} (expected: false)`);
+console.log(`  ✅ ${argv3.solve === false && argv3.hive === false ? 'PASS' : 'FAIL'}\n`);
+
+// Test 4: Mixed - disable only solve
+console.log('Test 4: Mixed - disable only solve with --no-solve');
+const argv4 = createParser(['--no-solve']).parseSync();
+console.log(`  solve: ${argv4.solve} (expected: false)`);
+console.log(`  hive: ${argv4.hive} (expected: true)`);
+console.log(`  ✅ ${argv4.solve === false && argv4.hive === true ? 'PASS' : 'FAIL'}\n`);
+
+console.log('All tests completed! ✅');

--- a/experiments/test-yargs-negation.mjs
+++ b/experiments/test-yargs-negation.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+/**
+ * Direct test of yargs negation behavior
+ */
+
+if (typeof use === 'undefined') {
+  globalThis.use = (await eval(await (await fetch('https://unpkg.com/use-m/use.js')).text())).use;
+}
+
+const yargsModule = await use('yargs@17.7.2');
+const yargs = yargsModule.default || yargsModule;
+
+console.log('Testing yargs negation behavior directly...\n');
+
+// Simulate: node script.js --no-solve --no-hive
+// Need to include node and script name like in real argv
+const testArgs = ['node', 'script.js', '--no-solve', '--no-hive'];
+
+const argv = yargs(testArgs.slice(2)) // Skip 'node' and 'script.js'
+  .option('solve', {
+    type: 'boolean',
+    description: 'Enable /solve command (use --no-solve to disable)',
+    default: true
+  })
+  .option('hive', {
+    type: 'boolean',
+    description: 'Enable /hive command (use --no-hive to disable)',
+    default: true
+  })
+  .parserConfiguration({
+    'boolean-negation': true
+  })
+  .parseSync();
+
+console.log('Input args:', testArgs);
+console.log('Parsed argv:', argv);
+console.log('argv.solve:', argv.solve);
+console.log('argv.hive:', argv.hive);
+console.log('argv["no-solve"]:', argv['no-solve']);
+console.log('argv.noSolve:', argv.noSolve);
+
+console.log('\n--- Environment check ---');
+console.log('Does yargs support negation? Testing with explicit check...');
+
+const solveEnabled = argv.solve !== false;
+const hiveEnabled = argv.hive !== false;
+
+console.log('solveEnabled (argv.solve !== false):', solveEnabled);
+console.log('hiveEnabled (argv.hive !== false):', hiveEnabled);

--- a/experiments/test-yargs-simple.mjs
+++ b/experiments/test-yargs-simple.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+if (typeof use === 'undefined') {
+  globalThis.use = (await eval(await (await fetch('https://unpkg.com/use-m/use.js')).text())).use;
+}
+
+const yargsModule = await use('yargs@17.7.2');
+const yargsFactory = yargsModule.default || yargsModule;
+
+console.log('Test 1: With --solve');
+const argv1 = yargsFactory(['--solve'])
+  .option('solve', { type: 'boolean', default: true })
+  .parseSync();
+console.log('argv.solve:', argv1.solve);
+
+console.log('\nTest 2: With --no-solve');
+const argv2 = yargsFactory(['--no-solve'])
+  .option('solve', { type: 'boolean', default: true })
+  .parseSync();
+console.log('argv.solve:', argv2.solve);
+
+console.log('\nTest 3: Without any option (should use default)');
+const argv3 = yargsFactory([])
+  .option('solve', { type: 'boolean', default: true })
+  .parseSync();
+console.log('argv.solve:', argv3.solve);
+
+console.log('\nTest 4: Check negation with boolean() method');
+const argv4 = yargsFactory(['--no-solve'])
+  .boolean('solve')
+  .default('solve', true)
+  .parseSync();
+console.log('argv.solve:', argv4.solve);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deep-assistant/hive-mind",
-  "version": "0.21.13",
+  "version": "0.21.14",
   "description": "AI-powered issue solver and hive mind for collaborative problem solving",
   "main": "src/hive.mjs",
   "type": "module",

--- a/src/telegram-bot.mjs
+++ b/src/telegram-bot.mjs
@@ -41,18 +41,21 @@ const argv = yargs(hideBin(process.argv))
     type: 'string',
     description: 'Override options for /hive command in lino notation, e.g., "(\n  --verbose\n  --all-issues\n)"'
   })
-  .option('no-solve', {
+  .option('solve', {
     type: 'boolean',
-    description: 'Disable /solve command',
-    default: false
+    description: 'Enable /solve command (use --no-solve to disable)',
+    default: true
   })
-  .option('no-hive', {
+  .option('hive', {
     type: 'boolean',
-    description: 'Disable /hive command',
-    default: false
+    description: 'Enable /hive command (use --no-hive to disable)',
+    default: true
   })
   .help('h')
   .alias('h', 'help')
+  .parserConfiguration({
+    'boolean-negation': true
+  })
   .parse();
 
 const BOT_TOKEN = argv.token || process.env.TELEGRAM_BOT_TOKEN;
@@ -90,8 +93,12 @@ const hiveOverrides = hiveOverridesInput
   : [];
 
 // Command enable/disable flags
-const solveEnabled = !(argv.noSolve || argv['no-solve'] || process.env.TELEGRAM_NO_SOLVE === 'true');
-const hiveEnabled = !(argv.noHive || argv['no-hive'] || process.env.TELEGRAM_NO_HIVE === 'true');
+// Note: yargs automatically supports --no-solve and --no-hive for negation
+// Check both the camelCase and kebab-case versions
+const solveEnabled = argv.solve !== false &&
+  (process.env.TELEGRAM_SOLVE === undefined || process.env.TELEGRAM_SOLVE !== 'false');
+const hiveEnabled = argv.hive !== false &&
+  (process.env.TELEGRAM_HIVE === undefined || process.env.TELEGRAM_HIVE !== 'false');
 
 function isChatAuthorized(chatId) {
   if (!allowedChats) {

--- a/src/telegram-bot.mjs
+++ b/src/telegram-bot.mjs
@@ -33,6 +33,24 @@ const argv = yargs(hideBin(process.argv))
     description: 'Allowed chat IDs in lino notation, e.g., "(\n  123456789\n  987654321\n)"',
     alias: 'a'
   })
+  .option('solve-overrides', {
+    type: 'string',
+    description: 'Override options for /solve command in lino notation, e.g., "(\n  --auto-continue\n  --attach-logs\n)"'
+  })
+  .option('hive-overrides', {
+    type: 'string',
+    description: 'Override options for /hive command in lino notation, e.g., "(\n  --verbose\n  --all-issues\n)"'
+  })
+  .option('no-solve', {
+    type: 'boolean',
+    description: 'Disable /solve command',
+    default: false
+  })
+  .option('no-hive', {
+    type: 'boolean',
+    description: 'Disable /hive command',
+    default: false
+  })
   .help('h')
   .alias('h', 'help')
   .parse();
@@ -59,6 +77,21 @@ const allowedChatsInput = argv.allowedChats || argv['allowed-chats'] || process.
 const allowedChats = allowedChatsInput
   ? lino.parseNumericIds(allowedChatsInput)
   : null;
+
+// Parse override options
+const solveOverridesInput = argv.solveOverrides || argv['solve-overrides'] || process.env.TELEGRAM_SOLVE_OVERRIDES;
+const solveOverrides = solveOverridesInput
+  ? lino.parse(solveOverridesInput).filter(line => line.trim())
+  : [];
+
+const hiveOverridesInput = argv.hiveOverrides || argv['hive-overrides'] || process.env.TELEGRAM_HIVE_OVERRIDES;
+const hiveOverrides = hiveOverridesInput
+  ? lino.parse(hiveOverridesInput).filter(line => line.trim())
+  : [];
+
+// Command enable/disable flags
+const solveEnabled = !(argv.noSolve || argv['no-solve'] || process.env.TELEGRAM_NO_SOLVE === 'true');
+const hiveEnabled = !(argv.noHive || argv['no-hive'] || process.env.TELEGRAM_NO_HIVE === 'true');
 
 function isChatAuthorized(chatId) {
   if (!allowedChats) {
@@ -207,6 +240,49 @@ function parseCommandArgs(text) {
   return args;
 }
 
+function mergeArgsWithOverrides(userArgs, overrides) {
+  if (!overrides || overrides.length === 0) {
+    return userArgs;
+  }
+
+  // Parse overrides to identify flags and their values
+  const overrideFlags = new Map(); // Map of flag -> value (or null for boolean flags)
+
+  for (let i = 0; i < overrides.length; i++) {
+    const arg = overrides[i];
+    if (arg.startsWith('--')) {
+      // Check if next item is a value (doesn't start with --)
+      if (i + 1 < overrides.length && !overrides[i + 1].startsWith('--')) {
+        overrideFlags.set(arg, overrides[i + 1]);
+        i++; // Skip the value in next iteration
+      } else {
+        overrideFlags.set(arg, null); // Boolean flag
+      }
+    }
+  }
+
+  // Filter user args to remove any that conflict with overrides
+  const filteredArgs = [];
+  for (let i = 0; i < userArgs.length; i++) {
+    const arg = userArgs[i];
+    if (arg.startsWith('--')) {
+      // If this flag exists in overrides, skip it and its value
+      if (overrideFlags.has(arg)) {
+        // Skip the flag
+        // Also skip next arg if it's a value (doesn't start with --)
+        if (i + 1 < userArgs.length && !userArgs[i + 1].startsWith('--')) {
+          i++; // Skip the value too
+        }
+        continue;
+      }
+    }
+    filteredArgs.push(arg);
+  }
+
+  // Merge: filtered user args + overrides
+  return [...filteredArgs, ...overrides];
+}
+
 function validateGitHubUrl(args) {
   if (args.length === 0) {
     return {
@@ -237,12 +313,31 @@ bot.command('help', async (ctx) => {
   message += `• Chat Type: ${chatType}\n`;
   message += `• Chat Title: ${chatTitle}\n\n`;
   message += `📝 *Available Commands:*\n\n`;
-  message += `*/solve* - Solve a GitHub issue\n`;
-  message += `Usage: \`/solve <github-url> [options]\`\n`;
-  message += `Example: \`/solve https://github.com/owner/repo/issues/123 --verbose\`\n\n`;
-  message += `*/hive* - Run hive command\n`;
-  message += `Usage: \`/hive <github-url> [options]\`\n`;
-  message += `Example: \`/hive https://github.com/owner/repo --model sonnet\`\n\n`;
+
+  if (solveEnabled) {
+    message += `*/solve* - Solve a GitHub issue\n`;
+    message += `Usage: \`/solve <github-url> [options]\`\n`;
+    message += `Example: \`/solve https://github.com/owner/repo/issues/123 --verbose\`\n`;
+    if (solveOverrides.length > 0) {
+      message += `🔒 Locked options: \`${solveOverrides.join(' ')}\`\n`;
+    }
+    message += `\n`;
+  } else {
+    message += `*/solve* - ❌ Disabled\n\n`;
+  }
+
+  if (hiveEnabled) {
+    message += `*/hive* - Run hive command\n`;
+    message += `Usage: \`/hive <github-url> [options]\`\n`;
+    message += `Example: \`/hive https://github.com/owner/repo --model sonnet\`\n`;
+    if (hiveOverrides.length > 0) {
+      message += `🔒 Locked options: \`${hiveOverrides.join(' ')}\`\n`;
+    }
+    message += `\n`;
+  } else {
+    message += `*/hive* - ❌ Disabled\n\n`;
+  }
+
   message += `*/help* - Show this help message\n\n`;
   message += `⚠️ *Note:* /solve and /hive commands only work in group chats.\n\n`;
   message += `🔧 *Available Options:*\n`;
@@ -262,6 +357,11 @@ bot.command('help', async (ctx) => {
 });
 
 bot.command('solve', async (ctx) => {
+  if (!solveEnabled) {
+    await ctx.reply('❌ The /solve command is disabled on this bot instance.');
+    return;
+  }
+
   if (!isGroupChat(ctx)) {
     await ctx.reply('❌ The /solve command only works in group chats. Please add this bot to a group and make it an admin.');
     return;
@@ -273,15 +373,22 @@ bot.command('solve', async (ctx) => {
     return;
   }
 
-  const args = parseCommandArgs(ctx.message.text);
+  const userArgs = parseCommandArgs(ctx.message.text);
 
-  const validation = validateGitHubUrl(args);
+  const validation = validateGitHubUrl(userArgs);
   if (!validation.valid) {
     await ctx.reply(`❌ ${validation.error}\n\nExample: \`/solve https://github.com/owner/repo/issues/123 --verbose\``, { parse_mode: 'Markdown' });
     return;
   }
 
-  await ctx.reply(`🚀 Starting solve command...\nURL: ${args[0]}\nOptions: ${args.slice(1).join(' ') || 'none'}`);
+  // Merge user args with overrides
+  const args = mergeArgsWithOverrides(userArgs, solveOverrides);
+
+  let statusMsg = `🚀 Starting solve command...\nURL: ${args[0]}\nOptions: ${args.slice(1).join(' ') || 'none'}`;
+  if (solveOverrides.length > 0) {
+    statusMsg += `\n🔒 Locked options: ${solveOverrides.join(' ')}`;
+  }
+  await ctx.reply(statusMsg);
 
   const result = await executeStartScreen('solve', args);
 
@@ -309,6 +416,11 @@ bot.command('solve', async (ctx) => {
 });
 
 bot.command('hive', async (ctx) => {
+  if (!hiveEnabled) {
+    await ctx.reply('❌ The /hive command is disabled on this bot instance.');
+    return;
+  }
+
   if (!isGroupChat(ctx)) {
     await ctx.reply('❌ The /hive command only works in group chats. Please add this bot to a group and make it an admin.');
     return;
@@ -320,15 +432,22 @@ bot.command('hive', async (ctx) => {
     return;
   }
 
-  const args = parseCommandArgs(ctx.message.text);
+  const userArgs = parseCommandArgs(ctx.message.text);
 
-  const validation = validateGitHubUrl(args);
+  const validation = validateGitHubUrl(userArgs);
   if (!validation.valid) {
     await ctx.reply(`❌ ${validation.error}\n\nExample: \`/hive https://github.com/owner/repo --verbose\``, { parse_mode: 'Markdown' });
     return;
   }
 
-  await ctx.reply(`🚀 Starting hive command...\nURL: ${args[0]}\nOptions: ${args.slice(1).join(' ') || 'none'}`);
+  // Merge user args with overrides
+  const args = mergeArgsWithOverrides(userArgs, hiveOverrides);
+
+  let statusMsg = `🚀 Starting hive command...\nURL: ${args[0]}\nOptions: ${args.slice(1).join(' ') || 'none'}`;
+  if (hiveOverrides.length > 0) {
+    statusMsg += `\n🔒 Locked options: ${hiveOverrides.join(' ')}`;
+  }
+  await ctx.reply(statusMsg);
 
   const result = await executeStartScreen('hive', args);
 
@@ -375,6 +494,16 @@ if (allowedChats && allowedChats.length > 0) {
   console.log('Allowed chats (lino):', lino.format(allowedChats));
 } else {
   console.log('Allowed chats: All (no restrictions)');
+}
+console.log('Commands enabled:', {
+  solve: solveEnabled,
+  hive: hiveEnabled
+});
+if (solveOverrides.length > 0) {
+  console.log('Solve overrides (lino):', lino.format(solveOverrides));
+}
+if (hiveOverrides.length > 0) {
+  console.log('Hive overrides (lino):', lino.format(hiveOverrides));
 }
 
 bot.launch()


### PR DESCRIPTION
## 🤖 Summary

This PR implements an options override system for the Telegram bot, allowing administrators to lock specific command options and prevent users from changing them. This is useful for enforcing consistent behavior across all bot users.

Fixes #434

## 📋 Changes

### Core Features

1. **Options Override System**
   - Separate override configurations for `/solve` and `/hive` commands
   - Support for both boolean flags (e.g., `--verbose`, `--auto-continue`) and duplet options (e.g., `--tool opencode`, `--model sonnet`)
   - Intelligent argument merging that removes conflicting user options before applying overrides
   - Configuration via CLI arguments or environment variables

2. **Command Enable/Disable**
   - Added `--solve` and `--hive` options (default: `true`) with yargs auto-negation support
   - Users can disable commands using `--no-solve` or `--no-hive` (yargs automatic negation)
   - Commands show appropriate error messages when disabled
   - Status reflected in `/help` command output

3. **User Experience Improvements**
   - Visual indicators showing locked options in command responses
   - Updated `/help` command to display:
     - Which commands are enabled/disabled
     - Currently locked options for each command
   - Startup logging shows configuration details

### Configuration Options

**CLI Arguments:**
- `--solve-overrides` - Override options for /solve command (lino notation)
- `--hive-overrides` - Override options for /hive command (lino notation)
- `--solve` / `--no-solve` - Enable/disable /solve command (default: enabled)
- `--hive` / `--no-hive` - Enable/disable /hive command (default: enabled)

**Environment Variables:**
- `TELEGRAM_SOLVE_OVERRIDES` - Override options for /solve command
- `TELEGRAM_HIVE_OVERRIDES` - Override options for /hive command
- `TELEGRAM_SOLVE` - Enable/disable /solve command (set to "false" to disable, default: true)
- `TELEGRAM_HIVE` - Enable/disable /hive command (set to "false" to disable, default: true)

### Example Usage

```bash
# Lock specific options for solve command
hive-telegram-bot --solve-overrides "(
  --auto-continue
  --attach-logs
  --verbose
  --tool opencode
)"

# Disable hive command
hive-telegram-bot --no-hive

# Or via environment variables
export TELEGRAM_SOLVE_OVERRIDES="(
  --auto-continue
  --attach-logs
  --verbose
  --tool opencode
)"
export TELEGRAM_HIVE=false
hive-telegram-bot
```

When users run `/solve https://github.com/owner/repo/issues/123 --tool haiku --fork`:
- The `--tool haiku` is replaced with `--tool opencode` (override)
- The `--fork` is preserved (not overridden)
- Additional locked options (`--auto-continue`, `--attach-logs`, `--verbose`) are added

### Implementation Details

**`mergeArgsWithOverrides()` function:**
1. Parses override options to identify flags and their values
2. Filters user arguments to remove any that conflict with overrides
3. Merges filtered user args with overrides
4. Properly handles both boolean flags and value-based options

**Override Logic:**
- If user provides `--tool haiku` and override is `--tool opencode`, user's option is removed
- If user provides `--verbose` and override also has `--verbose`, duplication is prevented
- URL and non-conflicting options are always preserved

**Options Design:**
- Uses positive form (`--solve`, `--hive`) with default `true`
- Yargs automatically supports negation via `--no-solve` and `--no-hive`
- Follows yargs best practices for boolean option negation

## 🧪 Testing

- Created comprehensive test suite: `examples/test-telegram-bot-overrides.mjs`
- All 8 test cases pass, covering:
  - Boolean flag overrides
  - Duplet option overrides
  - Multiple overrides
  - Complex real-world scenarios
  - URL preservation

## 📝 Documentation

- Updated `.env.example` with all new configuration options
- Added inline code comments explaining override logic
- Help command now displays override status

## ✅ Checklist

- [x] Implementation follows existing code style
- [x] Comprehensive tests added and passing
- [x] Documentation updated (.env.example)
- [x] No breaking changes to existing functionality
- [x] Error handling for disabled commands
- [x] User-friendly feedback messages
- [x] Uses positive form for boolean options per yargs best practices

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)